### PR TITLE
Disable create Project Button after first click

### DIFF
--- a/src/layouts/projects/CreateProjectModal.tsx
+++ b/src/layouts/projects/CreateProjectModal.tsx
@@ -76,14 +76,8 @@ export const CreateProjectModal: React.FC<CreateProjectModalProps> = ({
         sourceBible: null,
         books: [],
       });
-      setIsSubmitting(false);
     }
-  }, [isOpen]);
-
-  useEffect(() => {
-    if (!isOpen) {
-      setIsSubmitting(false);
-    }
+    setIsSubmitting(false);
   }, [isOpen]);
 
   useEffect(() => {
@@ -184,7 +178,6 @@ export const CreateProjectModal: React.FC<CreateProjectModalProps> = ({
             <DialogTitle>{t('createProject')}</DialogTitle>
           </DialogHeader>
           <div className='space-y-6 py-6'>
-            {/* Project Title */}
             <div className='space-y-2'>
               <Label className='gap-1' htmlFor='title'>
                 <span style={{ color: 'red' }}>*</span>

--- a/src/layouts/projects/CreateProjectModal.tsx
+++ b/src/layouts/projects/CreateProjectModal.tsx
@@ -51,6 +51,7 @@ export const CreateProjectModal: React.FC<CreateProjectModalProps> = ({
   error = null,
 }) => {
   const { t } = useTranslation();
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const [formData, setFormData] = useState<FormData>({
     title: '',
@@ -75,6 +76,13 @@ export const CreateProjectModal: React.FC<CreateProjectModalProps> = ({
         sourceBible: null,
         books: [],
       });
+      setIsSubmitting(false);
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setIsSubmitting(false);
     }
   }, [isOpen]);
 
@@ -109,11 +117,14 @@ export const CreateProjectModal: React.FC<CreateProjectModalProps> = ({
   };
 
   const handleSubmit = async (): Promise<void> => {
+    if (isSubmitting) {
+      return;
+    }
     try {
       if (!formData.targetLanguage || !formData.sourceLanguage || !formData.sourceBible) {
         return;
       }
-
+      setIsSubmitting(true);
       const projectData: CreateProjectData = {
         title: formData.title,
         targetLanguage: formData.targetLanguage,
@@ -127,6 +138,7 @@ export const CreateProjectModal: React.FC<CreateProjectModalProps> = ({
       Logger.logException(error instanceof Error ? error : new Error(String(error)), {
         source: 'create project submit',
       });
+      setIsSubmitting(false);
     }
   };
 
@@ -144,7 +156,7 @@ export const CreateProjectModal: React.FC<CreateProjectModalProps> = ({
     }
   };
 
-  const isButtonDisabled = isLoading || !isFormValid();
+  const isButtonDisabled = isLoading || isSubmitting || !isFormValid();
 
   if (languagesError) {
     return (
@@ -235,11 +247,17 @@ export const CreateProjectModal: React.FC<CreateProjectModalProps> = ({
                   />
                 </SelectTrigger>
                 <SelectContent>
-                  {sourceBibles?.map(bible => (
-                    <SelectItem key={bible.id} value={bible.id.toString()}>
-                      {bible.name} ({bible.abbreviation})
-                    </SelectItem>
-                  ))}
+                  {!sourceBibles || sourceBibles.length === 0 ? (
+                    <div className='p-1 text-center text-sm text-gray-500'>
+                      No source Bible available
+                    </div>
+                  ) : (
+                    sourceBibles.map(bible => (
+                      <SelectItem key={bible.id} value={bible.id.toString()}>
+                        {bible.name} ({bible.abbreviation})
+                      </SelectItem>
+                    ))
+                  )}
                 </SelectContent>
               </Select>
             </div>

--- a/src/layouts/projects/CreateProjectModal.tsx
+++ b/src/layouts/projects/CreateProjectModal.tsx
@@ -242,7 +242,7 @@ export const CreateProjectModal: React.FC<CreateProjectModalProps> = ({
                 <SelectContent>
                   {!sourceBibles || sourceBibles.length === 0 ? (
                     <div className='p-1 text-center text-sm text-gray-500'>
-                      No source Bible available
+                      No bibles for this language
                     </div>
                   ) : (
                     sourceBibles.map(bible => (


### PR DESCRIPTION
This PR contains fixes for the following :
- Disable the Create Project Button on first Click.
- add a message in a dropdown when there is no available Source Bible for the selected Source Language. 