### PR TITLE
added fix for  progress bar and close icon

### DIFF
--- a/src/layouts/bible/DraftingPage.tsx
+++ b/src/layouts/bible/DraftingPage.tsx
@@ -503,7 +503,7 @@ const DraftingUI: React.FC<DraftingUIProps> = ({
               >
                 <BookText color='#ffffff' />
               </Button>
-              <div className='bg-input rounded-lg border md:w-50 lg:w-76 xl:w-105'>
+              <div className='bg-input rounded-lg border sm:w-40 md:w-50 lg:w-76 xl:w-105'>
                 <div className='h-4 overflow-hidden rounded-full'>
                   <div
                     className='bg-primary h-full rounded-full transition-all duration-300'

--- a/src/layouts/resources/ResourceDialog.tsx
+++ b/src/layouts/resources/ResourceDialog.tsx
@@ -171,7 +171,7 @@ export const ResourceDialog: React.FC<ResourceDialogProps> = ({
         showCloseButton={false}
       >
         <DialogHeader
-          className={`sticky top-0 z-20 flex items-center justify-between px-6 py-2 ${
+          className={`sticky top-0 z-20 flex items-center justify-between py-2 pr-3 pl-6 ${
             isRTL ? 'flex-row-reverse' : 'flex-row'
           }`}
           style={{


### PR DESCRIPTION
PR  includes :- 
-  progress bar supported till **sm** break point (ie, Minimum width- 40rem (640px) ) 

-  moved the close icon of the translation notes resource dialog to the left.