### PR TITLE
Pin package manager in container

### DIFF
--- a/.github/workflows/post-merge-deploy.yml
+++ b/.github/workflows/post-merge-deploy.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: pnpm/action-setup@v5
         with:
-          version: 10
+          version: 10.33.0
 
       - uses: actions/setup-node@v6
         with:
@@ -39,7 +39,7 @@ jobs:
           action: upload
           app_location: /
           output_location: dist
-          app_build_command: npm install -g pnpm@10 && pnpm install && pnpm build
+          app_build_command: npm install -g pnpm@10.33.0 && pnpm install && pnpm build
         env:
           VITE_API_URL: ${{ secrets.VITE_API_URL }}
           VITE_APP_INSIGHTS_KEY: ${{ secrets.VITE_APP_INSIGHTS_KEY }}

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: 10
+          version: 10.33.0
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,7 +4,7 @@ FROM node:24.13.0-alpine
 RUN apk update && \
     apk upgrade && \
     apk add --no-cache dumb-init && \
-    corepack enable && corepack prepare pnpm@9 --activate && \
+    corepack enable && corepack prepare pnpm@10.33.0 --activate && \
     npm cache clean --force && \
     rm -rf /var/cache/apk/* /tmp/*
 

--- a/docs/environment-config.md
+++ b/docs/environment-config.md
@@ -86,10 +86,10 @@ VITE_API_URL=http://localhost:8080 ./fweb.sh up
 
 The following variables are pre-configured inside the container:
 
-| Variable                   | Value                  | Purpose                                          |
-| -------------------------- | ---------------------- | ------------------------------------------------ |
-| `COREPACK_HOME`            | `/app/.cache/corepack` | Corepack cache location                          |
-| `COREPACK_ENABLE_AUTO_PIN` | `0`                    | Disable auto-pinning for consistent pnpm version |
+| Variable                   | Value                  | Purpose                                                  |
+| -------------------------- | ---------------------- | -------------------------------------------------------- |
+| `COREPACK_HOME`            | `/app/.cache/corepack` | Corepack cache location - removed: caused caching issues |
+| `COREPACK_ENABLE_AUTO_PIN` | `0`                    | Disable auto-pinning for consistent pnpm version         |
 
 ### Switching Environments in Containers
 

--- a/fweb.ps1
+++ b/fweb.ps1
@@ -47,7 +47,7 @@ function Test-ContainerRunning {
 
 function Build-Image {
     Write-Host "Building image $ImageName..."
-    & $Runtime build -t $ImageName -f Dockerfile.dev .
+    & $Runtime build --no-cache -t $ImageName -f Dockerfile.dev .
 }
 
 function Run-Container {
@@ -79,8 +79,8 @@ function Run-Container {
     # Environment variables
     $envVars = @(
         "-e", "VITE_API_URL=$ViteApiUrl",
-        "-e", "COREPACK_HOME=/app/.cache/corepack",
-        "-e", "COREPACK_ENABLE_AUTO_PIN=0"
+        "-e", "COREPACK_ENABLE_AUTO_PIN=0",
+        "-e", "CI=true"
     )
 
     # Load additional env vars from .env if it exists
@@ -104,7 +104,6 @@ function Run-Container {
         "-p", "${Port}:5173"
     ) + $volumeMounts + $envVars + @(
         "--user", "1001:1001",
-        "--read-only",
         "--tmpfs", "/tmp:nosuid,size=64m",
         "--security-opt", "no-new-privileges:true",
         "--cap-drop", "ALL",

--- a/fweb.sh
+++ b/fweb.sh
@@ -39,7 +39,7 @@ container_running() {
 
 build_image() {
   echo "Building image $IMAGE_NAME..."
-  $RUNTIME build -t "$IMAGE_NAME" -f Dockerfile.dev .
+  $RUNTIME build --no-cache -t "$IMAGE_NAME" -f Dockerfile.dev .
 }
 
 run_container() {
@@ -71,8 +71,8 @@ run_container() {
   # Environment variables
   local -a env_flags=(
     -e "VITE_API_URL=$VITE_API_URL"
-    -e "COREPACK_HOME=/app/.cache/corepack"
     -e "COREPACK_ENABLE_AUTO_PIN=0"
+    -e "CI=true"
   )
 
   # Load additional env vars from .env if it exists
@@ -95,7 +95,6 @@ run_container() {
     "${volume_flags[@]}" \
     "${env_flags[@]}" \
     --user "1001:1001" \
-    --read-only \
     --tmpfs /tmp:nosuid,size=64m \
     --security-opt no-new-privileges:true \
     --cap-drop ALL \

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
+  "packageManager": "pnpm@10.33.0",
   "engines": {
     "node": "24.13.x"
   },


### PR DESCRIPTION
The container was caching the corepack files. This prevented the container from using the declared version of PNPM.