### PR TITLE
Fix back navigation from My History tab to My Work tab

### DIFF
--- a/src/features/auth/LoginPage.test.tsx
+++ b/src/features/auth/LoginPage.test.tsx
@@ -2,23 +2,27 @@ import { type ReactNode } from 'react';
 
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { LoginPage } from '@/features/auth/LoginPage';
 
 import type * as ReactRouter from '@tanstack/react-router';
 
-const { mockSignInEmail, mockRequestPasswordReset } = vi.hoisted(() => ({
-  mockSignInEmail: vi.fn(),
-  mockRequestPasswordReset: vi.fn(),
-}));
+const { mockSignInEmail, mockRequestPasswordReset, mockUseSearch, mockUseSession } = vi.hoisted(
+  () => ({
+    mockSignInEmail: vi.fn(),
+    mockRequestPasswordReset: vi.fn(),
+    mockUseSearch: vi.fn(() => ({}) as { returnTo?: string }),
+    mockUseSession: vi.fn(() => ({ data: null, isPending: false }) as object),
+  })
+);
 
 // Decouple from the real router so LoginPage renders without a RouterProvider.
 vi.mock('@tanstack/react-router', async importOriginal => {
   const actual = await importOriginal<typeof ReactRouter>();
   return {
     ...actual,
-    useSearch: () => ({}),
+    useSearch: () => mockUseSearch(),
     Link: ({ children, to }: { children: ReactNode; to?: string }) => (
       <a href={to ?? '#'}>{children}</a>
     ),
@@ -29,6 +33,7 @@ vi.mock('@/lib/auth-client', () => ({
   authClient: {
     signIn: { email: mockSignInEmail },
     requestPasswordReset: mockRequestPasswordReset,
+    useSession: () => mockUseSession(),
   },
 }));
 
@@ -41,6 +46,12 @@ function loginForm(container: HTMLElement) {
 describe('LoginPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseSearch.mockReturnValue({});
+    mockUseSession.mockReturnValue({ data: null, isPending: false });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('shows field errors and skips the API when the form is empty', async () => {
@@ -83,6 +94,61 @@ describe('LoginPage', () => {
         password: 'pm@123456',
       })
     );
+  });
+
+  it('replaces the history entry with returnTo after a successful sign-in', async () => {
+    mockSignInEmail.mockResolvedValue({ error: null });
+    mockUseSearch.mockReturnValue({ returnTo: '/projects/42' });
+    const replaceMock = vi.fn();
+    vi.stubGlobal('location', { ...window.location, replace: replaceMock });
+
+    const user = userEvent.setup();
+    const { container } = render(<LoginPage />);
+    const form = loginForm(container);
+
+    await user.type(form.getByPlaceholderText('Email address*'), 'pm@fluent.local');
+    await user.type(form.getByPlaceholderText('Password*'), 'pm@123456');
+    await user.click(form.getByRole('button', { name: /continue/i }));
+
+    await waitFor(() => expect(replaceMock).toHaveBeenCalledWith('/projects/42'));
+  });
+
+  it('ignores non-internal returnTo targets after sign-in', async () => {
+    mockSignInEmail.mockResolvedValue({ error: null });
+    mockUseSearch.mockReturnValue({ returnTo: 'https://evil.example/phish' });
+    const replaceMock = vi.fn();
+    vi.stubGlobal('location', { ...window.location, replace: replaceMock });
+
+    const user = userEvent.setup();
+    const { container } = render(<LoginPage />);
+    const form = loginForm(container);
+
+    await user.type(form.getByPlaceholderText('Email address*'), 'pm@fluent.local');
+    await user.type(form.getByPlaceholderText('Password*'), 'pm@123456');
+    await user.click(form.getByRole('button', { name: /continue/i }));
+
+    await waitFor(() => expect(replaceMock).toHaveBeenCalledWith('/'));
+  });
+
+  it('redirects an already-authenticated visitor away from the login page', async () => {
+    mockUseSession.mockReturnValue({ data: { user: { id: '1' } }, isPending: false });
+    mockUseSearch.mockReturnValue({ returnTo: '/?tab=my-history' });
+    const replaceMock = vi.fn();
+    vi.stubGlobal('location', { ...window.location, replace: replaceMock });
+
+    render(<LoginPage />);
+
+    await waitFor(() => expect(replaceMock).toHaveBeenCalledWith('/?tab=my-history'));
+  });
+
+  it('does not redirect while the session is still loading', () => {
+    mockUseSession.mockReturnValue({ data: null, isPending: true });
+    const replaceMock = vi.fn();
+    vi.stubGlobal('location', { ...window.location, replace: replaceMock });
+
+    render(<LoginPage />);
+
+    expect(replaceMock).not.toHaveBeenCalled();
   });
 
   it('shows the server error message when sign-in fails', async () => {

--- a/src/features/auth/LoginPage.tsx
+++ b/src/features/auth/LoginPage.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Link, useSearch } from '@tanstack/react-router';
 import { Eye, EyeOff, Mail } from 'lucide-react';
 
+import { resolveReturnTo } from '@/features/auth/return-to';
 import { authClient } from '@/lib/auth-client';
 import { Logger } from '@/lib/services/logger';
 
@@ -30,7 +31,17 @@ export function LoginPage() {
   const [isSendingReset, setIsSendingReset] = useState(false);
 
   const search = useSearch({ strict: false });
-  const returnTo = (search as { returnTo?: string }).returnTo ?? '/';
+  const returnTo = resolveReturnTo((search as { returnTo?: string }).returnTo);
+
+  // The /login route guard covers in-app navigation, but on a hard load it
+  // runs before the session has resolved. Once the session is known, send an
+  // already-authenticated visitor into the app instead of showing the form.
+  const { data: session, isPending: isSessionLoading } = authClient.useSession();
+  useEffect(() => {
+    if (!isSessionLoading && session) {
+      window.location.replace(returnTo);
+    }
+  }, [isSessionLoading, session, returnTo]);
 
   const isValidEmail = (email: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 
@@ -73,9 +84,10 @@ export function LoginPage() {
       if (signInError) {
         setGlobalLoginError(signInError.message ?? 'Wrong email or password');
       } else {
-        // Fix for redirect bug: perform a hard navigation to guarantee
-        // the session cookie is correctly validated by the new page load
-        window.location.href = returnTo;
+        // Hard navigation so the new page load validates the session cookie.
+        // replace() keeps /login out of history, so Back from the app never
+        // lands on the login form again.
+        window.location.replace(returnTo);
       }
     } catch (err) {
       Logger.logException(err instanceof Error ? err : new Error(String(err)), {

--- a/src/features/auth/return-to.ts
+++ b/src/features/auth/return-to.ts
@@ -1,0 +1,18 @@
+/**
+ * Resolve a `returnTo` search param to a safe in-app navigation target.
+ *
+ * Only same-origin paths are allowed ("/projects/42"). Anything else —
+ * absolute URLs, scheme-relative "//host", or "/\host" — falls back to the
+ * app home so the login flow can't be used as an open redirect. Targets on
+ * the login page itself also fall back, so redirects can't loop.
+ */
+export function resolveReturnTo(returnTo: string | undefined): string {
+  if (!returnTo?.startsWith('/') || returnTo.startsWith('//') || returnTo.startsWith('/\\')) {
+    return '/';
+  }
+  const pathname = returnTo.split(/[?#]/, 1)[0];
+  if (pathname === '/login' || pathname.startsWith('/login/')) {
+    return '/';
+  }
+  return returnTo;
+}

--- a/src/features/auth/route-guards.test.ts
+++ b/src/features/auth/route-guards.test.ts
@@ -5,14 +5,16 @@ import { type AuthContext } from '@/lib/router-context';
 import { UserRole } from '@/lib/types';
 import { Route as AuthenticatedRoute } from '@/routes/_authenticated';
 import { Route as UsersRoute } from '@/routes/_authenticated/users/index';
+import { Route as LoginRoute } from '@/routes/login';
 
 interface GuardArgs {
   context: { auth: AuthContext };
   location: { href: string };
+  search?: { returnTo?: string };
 }
 type Guard = (args: GuardArgs) => unknown;
 interface RedirectShape {
-  options?: { to?: string; search?: { returnTo?: string } };
+  options?: { to?: string; href?: string; search?: { returnTo?: string } };
 }
 
 const authContext = (overrides: Partial<AuthContext> = {}): AuthContext => ({
@@ -26,6 +28,7 @@ const authContext = (overrides: Partial<AuthContext> = {}): AuthContext => ({
 // they actually read, then invoke them with a controlled context.
 const authGuard = AuthenticatedRoute.options.beforeLoad as unknown as Guard;
 const usersGuard = UsersRoute.options.beforeLoad as unknown as Guard;
+const loginGuard = LoginRoute.options.beforeLoad as unknown as Guard;
 
 /** Run a guard and return the thrown redirect, or null if it passed through. */
 function captureRedirect(guard: Guard, args: GuardArgs): unknown {
@@ -62,6 +65,70 @@ describe('_authenticated route guard', () => {
       location: { href: '/projects' },
     });
     expect(thrown).toBeNull();
+  });
+});
+
+describe('/login route guard', () => {
+  it('does nothing while auth is still loading', () => {
+    const thrown = captureRedirect(loginGuard, {
+      context: { auth: authContext({ isLoading: true, isAuthenticated: true }) },
+      location: { href: '/login' },
+      search: {},
+    });
+    expect(thrown).toBeNull();
+  });
+
+  it('lets unauthenticated users through to the login form', () => {
+    const thrown = captureRedirect(loginGuard, {
+      context: { auth: authContext({ isAuthenticated: false }) },
+      location: { href: '/login' },
+      search: {},
+    });
+    expect(thrown).toBeNull();
+  });
+
+  it('redirects authenticated users to the app home when no returnTo is present', () => {
+    const thrown = captureRedirect(loginGuard, {
+      context: { auth: authContext({ isAuthenticated: true }) },
+      location: { href: '/login' },
+      search: {},
+    });
+    expect(isRedirect(thrown)).toBe(true);
+    expect((thrown as RedirectShape).options?.href).toBe('/');
+  });
+
+  it('redirects authenticated users to an internal returnTo path', () => {
+    const thrown = captureRedirect(loginGuard, {
+      context: { auth: authContext({ isAuthenticated: true }) },
+      location: { href: '/login' },
+      search: { returnTo: '/projects/42' },
+    });
+    expect(isRedirect(thrown)).toBe(true);
+    expect((thrown as RedirectShape).options?.href).toBe('/projects/42');
+  });
+
+  it('falls back to the app home for non-internal returnTo targets', () => {
+    for (const returnTo of ['https://evil.example/phish', '//evil.example', '/\\evil.example']) {
+      const thrown = captureRedirect(loginGuard, {
+        context: { auth: authContext({ isAuthenticated: true }) },
+        location: { href: '/login' },
+        search: { returnTo },
+      });
+      expect(isRedirect(thrown)).toBe(true);
+      expect((thrown as RedirectShape).options?.href).toBe('/');
+    }
+  });
+
+  it('never redirects back into the login page itself', () => {
+    for (const returnTo of ['/login', '/login?returnTo=%2F', '/login/nested']) {
+      const thrown = captureRedirect(loginGuard, {
+        context: { auth: authContext({ isAuthenticated: true }) },
+        location: { href: '/login' },
+        search: { returnTo },
+      });
+      expect(isRedirect(thrown)).toBe(true);
+      expect((thrown as RedirectShape).options?.href).toBe('/');
+    }
   });
 });
 

--- a/src/features/dashboard/user/UserHomePage.test.tsx
+++ b/src/features/dashboard/user/UserHomePage.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { UserHomePage } from '@/features/dashboard/user/UserHomePage';
+import { type User, type UserChapterAssignment } from '@/lib/types';
+import { useAppStore } from '@/store/store';
+
+import type * as ReactRouter from '@tanstack/react-router';
+
+const { mockNavigate, mockUseSearch, mockUseChapterAssignments } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockUseSearch: vi.fn(() => ({}) as { tab?: 'my-work' | 'my-history' }),
+  mockUseChapterAssignments: vi.fn(),
+}));
+
+// Decouple from the real router so UserHomePage renders without a RouterProvider.
+vi.mock('@tanstack/react-router', async importOriginal => {
+  const actual = await importOriginal<typeof ReactRouter>();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useSearch: () => mockUseSearch(),
+  };
+});
+
+vi.mock('@/hooks/useChapterAssignment', () => ({
+  useChapterAssignmentsByUserId: () => mockUseChapterAssignments() as unknown,
+}));
+
+const assignment = (overrides: Partial<UserChapterAssignment>): UserChapterAssignment => ({
+  chapterAssignmentId: 1,
+  projectName: 'Project A',
+  projectUnitId: 10,
+  bibleId: 1,
+  bibleName: 'Test Bible',
+  chapterStatus: 'draft',
+  targetLanguage: 'Spanish',
+  sourceLangCode: 'eng',
+  bookCode: 'GEN',
+  bookId: 1,
+  book: 'Genesis',
+  chapterNumber: 1,
+  totalVerses: 31,
+  completedVerses: 3,
+  submittedTime: null,
+  ...overrides,
+});
+
+// One in-progress chapter (My Work) and one submitted chapter (My History).
+const workChapter = assignment({ book: 'Genesis' });
+const historyChapter = assignment({
+  chapterAssignmentId: 2,
+  book: 'Exodus',
+  bookId: 2,
+  chapterStatus: 'complete',
+  completedVerses: 31,
+  submittedTime: '2026-06-01T00:00:00.000Z',
+});
+
+describe('UserHomePage tabs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAppStore.setState({ userdetail: { id: 7, role: 2 } as unknown as User });
+    mockUseSearch.mockReturnValue({});
+    mockUseChapterAssignments.mockReturnValue({
+      data: { assignedChapters: [workChapter, historyChapter], peerCheckChapters: [] },
+      isLoading: false,
+    });
+  });
+
+  it('shows the My Work tab when no tab is present in the URL', () => {
+    render(<UserHomePage />);
+
+    expect(screen.getByText('Progress')).toBeInTheDocument();
+    expect(screen.getByText('Genesis')).toBeInTheDocument();
+    expect(screen.queryByText('Exodus')).not.toBeInTheDocument();
+  });
+
+  it('shows the My History tab when the URL has ?tab=my-history', () => {
+    mockUseSearch.mockReturnValue({ tab: 'my-history' });
+
+    render(<UserHomePage />);
+
+    expect(screen.getByText('Submitted Date')).toBeInTheDocument();
+    expect(screen.getByText('Exodus')).toBeInTheDocument();
+    expect(screen.queryByText('Genesis')).not.toBeInTheDocument();
+  });
+
+  it('navigates with the tab search param when My History is clicked', async () => {
+    const user = userEvent.setup();
+    render(<UserHomePage />);
+
+    await user.click(screen.getByRole('button', { name: /my history/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/', search: { tab: 'my-history' } });
+  });
+
+  it('navigates back to a clean URL when My Work is clicked', async () => {
+    mockUseSearch.mockReturnValue({ tab: 'my-history' });
+    const user = userEvent.setup();
+    render(<UserHomePage />);
+
+    await user.click(screen.getByRole('button', { name: /my work/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/', search: {} });
+  });
+});

--- a/src/features/dashboard/user/UserHomePage.tsx
+++ b/src/features/dashboard/user/UserHomePage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
-import { useNavigate } from '@tanstack/react-router';
+import { useNavigate, useSearch } from '@tanstack/react-router';
 import { Loader2 } from 'lucide-react';
 
 import { MultiSelectFilter } from '@/components/MultiSelectFilter';
@@ -118,8 +118,12 @@ export function UserHomePage() {
   const [selectedBooks, setSelectedBooks] = useState<string[]>([]);
   const [selectedStatuses, setSelectedStatuses] = useState<string[]>([]);
 
-  const { userdetail, userDashboardTab, setUserDashboardTab } = useAppStore();
+  const { userdetail } = useAppStore();
   const navigate = useNavigate();
+  // The active tab lives in the URL so each switch is a browser history
+  // entry — Back from My History lands on My Work instead of leaving the page.
+  const { tab } = useSearch({ from: '/_authenticated/' });
+  const isHistory = tab === 'my-history';
   const { data: chapterAssignmentsData, isLoading: loading } = useChapterAssignmentsByUserId(
     (userdetail as User).id
   );
@@ -128,7 +132,7 @@ export function UserHomePage() {
   useEffect(() => {
     setSelectedBooks([]);
     setSelectedStatuses([]);
-  }, [userDashboardTab]);
+  }, [isHistory]);
 
   const myWorkData: UserChapterAssignment[] = useMemo(() => {
     if (!chapterAssignmentsData) return [];
@@ -162,7 +166,6 @@ export function UserHomePage() {
       });
   }, [chapterAssignmentsData]);
 
-  const isHistory = userDashboardTab === 'my-history';
   const currentData = isHistory ? historyData : myWorkData;
 
   const bookOptions = useMemo(() => {
@@ -251,21 +254,21 @@ export function UserHomePage() {
       <div className='mb-6 shrink-0'>
         <button
           className={`cursor-pointer border-b-3 px-1 pb-3 text-sm font-medium transition-colors ${
-            userDashboardTab === 'my-work'
+            !isHistory
               ? 'border-primary text-foreground'
               : 'text-foreground border-transparent hover:text-gray-700'
           }`}
-          onClick={() => setUserDashboardTab('my-work')}
+          onClick={() => void navigate({ to: '/', search: {} })}
         >
           My Work ({myWorkData.length})
         </button>
         <button
           className={`ml-6 cursor-pointer border-b-3 px-1 pb-3 text-sm font-medium transition-colors ${
-            userDashboardTab === 'my-history'
+            isHistory
               ? 'border-primary text-foreground'
               : 'text-foreground border-transparent hover:text-gray-700'
           }`}
-          onClick={() => setUserDashboardTab('my-history')}
+          onClick={() => void navigate({ to: '/', search: { tab: 'my-history' } })}
         >
           My History ({historyData.length})
         </button>

--- a/src/routes/_authenticated/index.tsx
+++ b/src/routes/_authenticated/index.tsx
@@ -1,7 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router';
+import { z } from 'zod';
 
 import { RoleBasedHomePage } from '@/components/RoleBasedHomePage';
 
 export const Route = createFileRoute('/_authenticated/')({
+  // The dashboard tab lives in the URL so tab switches are real history
+  // entries — Back from My History returns to My Work, not out of the page.
+  validateSearch: z.object({
+    tab: z.enum(['my-work', 'my-history']).optional(),
+  }),
   component: RoleBasedHomePage,
 });

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -1,11 +1,24 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, redirect } from '@tanstack/react-router';
 import { z } from 'zod';
 
 import { LoginPage } from '@/features/auth/LoginPage';
+import { resolveReturnTo } from '@/features/auth/return-to';
 
 export const Route = createFileRoute('/login')({
   validateSearch: z.object({
     returnTo: z.string().optional(),
   }),
+  beforeLoad: ({ context, search }) => {
+    // Don't do anything while auth is still loading
+    if (context.auth.isLoading) {
+      return;
+    }
+
+    // Already signed in (e.g. Back button landing on /login): send the user
+    // into the app instead of showing the login form again
+    if (context.auth.isAuthenticated) {
+      throw redirect({ href: resolveReturnTo(search.returnTo) });
+    }
+  },
   component: LoginPage,
 });

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -5,12 +5,10 @@ import { type ProjectItem, type User } from '@/lib/types';
 
 interface AppState {
   userdetail: User | null;
-  userDashboardTab: 'my-work' | 'my-history';
   currentProjectItem: ProjectItem | null;
   presenceWarning: string | null;
   _hasHydrated: boolean;
   setUserDetail: (user: User) => void;
-  setUserDashboardTab: (tab: 'my-work' | 'my-history') => void;
   setCurrentProjectItem: (projectItem: ProjectItem | null) => void;
   clearUserDetail: () => void;
   clearCurrentProjectItem: () => void;
@@ -26,13 +24,10 @@ export const useAppStore = create<AppState>()(
   persist(
     set => ({
       userdetail: null,
-      userDashboardTab: 'my-work',
       currentProjectItem: null,
       presenceWarning: null,
       _hasHydrated: false,
       setUserDetail: (userdetail: User) => set({ userdetail }),
-      setUserDashboardTab: (userDashboardTab: 'my-work' | 'my-history') =>
-        set({ userDashboardTab }),
       setCurrentProjectItem: (currentProjectItem: ProjectItem | null) =>
         set({ currentProjectItem }),
       clearUserDetail: () => set({ userdetail: null }),
@@ -44,7 +39,6 @@ export const useAppStore = create<AppState>()(
       name: 'app-store',
       partialize: state => ({
         userdetail: state.userdetail,
-        userDashboardTab: state.userDashboardTab,
         currentProjectItem: state.currentProjectItem,
       }),
       onRehydrateStorage: () => state => {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -5,6 +5,13 @@ import { afterAll, afterEach, beforeAll } from 'vitest';
 
 import { server } from './msw/server';
 
+// jsdom doesn't implement ResizeObserver; MultiSelectFilter and Radix read it.
+window.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
 // jsdom doesn't implement matchMedia; the theme + a few components read it.
 window.matchMedia = ((query: string) => ({
   matches: false,


### PR DESCRIPTION
## Summary

Fixes back navigation for translators: pressing **Back** from the **My History** tab no longer dumps an authenticated user on the Login page — it returns to **My Work**, as expected.

### Root cause

1. The My Work / My History tabs lived only in the persisted zustand store, so switching tabs never created a browser history entry — Back always left the dashboard entirely.
2. On successful login, `window.location.href = returnTo` **pushed** a new entry, leaving `/login` in the history stack directly beneath the dashboard — exactly where Back landed.
3. The `/login` route had no auth guard, so the authenticated user was shown the login form.

### Changes

- **Tab state moved into the URL** (`/?tab=my-history`) via `validateSearch` on `/_authenticated/`; each tab switch is a real history entry, so Back from My History lands on My Work. The `userDashboardTab` store field is gone. Returning from a chapter via Back also restores the tab you left from, since it is part of the URL.
- **`/login` is now guarded**: a `beforeLoad` redirect (for in-app navigation) plus a session-aware effect in `LoginPage` (for hard loads, mirroring `AuthenticatedLayout`) send authenticated visitors to a sanitized `returnTo` or the app home.
- **Login success uses `window.location.replace(returnTo)`** so `/login` no longer lingers in the history stack.
- `returnTo` values are sanitized to same-origin paths (no open redirect, never back into `/login`).

## Screenshots

> Screenshots live locally at `/home/henrique/gitdocs/eten-tech-foundation/.playwright-mcp/pr-302-v1/` (not committed). Drag each PNG from that folder into the matching slot below — GitHub will replace the placeholder line with the uploaded image.

### 1) Login page (fresh session)

Unauthenticated visit to `/` redirects to `/login?returnTo=%2F` — unchanged for logged-out users.

<img width="901" height="790" alt="01-login-page" src="https://github.com/user-attachments/assets/98fcd360-6530-44b8-81d4-f5e964b8fef5" />

---

### 2) My Work after login

Translator `t@fluent.local` lands on `/` with the My Work tab active.

<img width="901" height="790" alt="02-my-work-after-login" src="https://github.com/user-attachments/assets/27c23d76-8c8f-4291-bfbc-87e3d712f22e" />

---

### 3) My History tab is a real history entry

Clicking My History navigates to `/?tab=my-history` (note the Submitted Date column) — the tab switch is now part of browser history.

<img width="901" height="790" alt="03-my-history-tab" src="https://github.com/user-attachments/assets/c4e480b7-e788-45ba-b7b8-2fd6ff2f5f2c" />

---

### 4) Back from My History lands on My Work (the fix)

Pressing the browser Back button from My History returns to `/` with My Work active — not the Login page.

<img width="901" height="790" alt="04-back-lands-on-my-work" src="https://github.com/user-attachments/assets/ccb6bff0-436c-439a-aa04-1da486d88d74" />

---

### 5) Authenticated visit to /login bounces into the app

Navigating straight to `/login` with a live session (hard load) redirects to the dashboard instead of showing the login form.

<img width="901" height="790" alt="05-login-redirects-to-app" src="https://github.com/user-attachments/assets/fef048bf-5c55-4167-ae84-3786417be6f6" />

## Test plan

- [x] Unit: `/login` guard — loading no-op, unauthenticated pass-through, authenticated redirect, `returnTo` sanitization (external / `//` / `/login` loop targets)
- [x] Unit: `UserHomePage` — tab derived from URL search param, tab clicks navigate with `?tab=`
- [x] Unit: `LoginPage` — `location.replace(returnTo)` on success, authenticated visitor redirected away, no redirect while session loads
- [x] `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `pnpm test` (38 passing)
- [x] E2E (Playwright against the docker compose stack): login as translator → My History → **Back** → My Work; Back again does not reach `/login`; direct `/login` visit while authenticated bounces to the dashboard

Closes #290

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safer login redirects with validated, internal-only return destinations and corrected post-login navigation behavior.
  * Authenticated users are redirected appropriately and login redirects never target the login page itself.

* **New Features**
  * Dashboard tabs now driven by the URL, enabling browser history, back/forward navigation, and shareable links.
  * Login route now guards authenticated access and respects validated return destinations.

* **Tests**
  * Expanded tests for login redirects, route guards, and dashboard tab behavior.
  * Test environment: added a no-op ResizeObserver to stabilize UI tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->