### PR TITLE
Progress Bar to Use Phase-Based Color System

### DIFF
--- a/src/features/projects/components/ProjectDetailPage.tsx
+++ b/src/features/projects/components/ProjectDetailPage.tsx
@@ -100,7 +100,7 @@ const CardProgressBar: React.FC<{
         {legendItems.map(item => (
           <div key={item.key} className='flex items-center gap-2'>
             <div
-              className='border-border h-4 w-4 shrink-0 rounded-none border'
+              className='h-4 w-4 shrink-0 rounded-none'
               style={{ backgroundColor: item.color }}
             />
             <span className='text-muted-foreground text-xs'>{item.displayName}</span>

--- a/src/features/projects/components/ProjectDetailPage.tsx
+++ b/src/features/projects/components/ProjectDetailPage.tsx
@@ -63,13 +63,13 @@ const CardProgressBar: React.FC<{
   chapterStatusCounts: ChapterStatusCounts;
   workflowConfig: WorkflowStep[];
 }> = ({ chapterStatusCounts, workflowConfig }) => {
-  const { colors, calculateProgressSegments } = useProgressBar(workflowConfig);
+  const { legendItems, calculateProgressSegments } = useProgressBar(workflowConfig);
   const segments = calculateProgressSegments(chapterStatusCounts);
 
   return (
     <div className='space-y-2'>
       <TooltipProvider delayDuration={100}>
-        <div className='border-border flex h-6 w-full overflow-hidden border'>
+        <div className='flex h-[7px] w-full overflow-hidden rounded-full'>
           {segments.length === 0 ? (
             <div className='bg-primary/10 h-full w-full' />
           ) : (
@@ -96,19 +96,16 @@ const CardProgressBar: React.FC<{
         </div>
       </TooltipProvider>
 
-      <div className='flex flex-wrap gap-x-2 gap-y-1.5 pt-1'>
-        {[...workflowConfig].reverse().map(step => {
-          const colorInfo = colors[step.id];
-          return (
-            <div key={step.id} className='flex items-center gap-2'>
-              <div
-                className='h-4 w-4 shrink-0 rounded-none'
-                style={{ backgroundColor: colorInfo.rgba }}
-              />
-              <span className='text-muted-foreground text-xs'>{step.label}</span>
-            </div>
-          );
-        })}
+      <div className='grid grid-cols-2 gap-x-8 gap-y-2 pt-1'>
+        {legendItems.map(item => (
+          <div key={item.key} className='flex items-center gap-2'>
+            <div
+              className='border-border h-4 w-4 shrink-0 rounded-none border'
+              style={{ backgroundColor: item.color }}
+            />
+            <span className='text-muted-foreground text-xs'>{item.displayName}</span>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/src/features/projects/components/ProjectPage.tsx
+++ b/src/features/projects/components/ProjectPage.tsx
@@ -38,11 +38,11 @@ const ProjectProgressBar: React.FC<{ project: Project }> = ({ project }) => {
   const segments = calculateProgressSegments(project.chapterStatusCounts);
 
   if (segments.length === 0) {
-    return <div className='border-border bg-primary/10 h-6 w-full border' />;
+    return <div className='bg-primary/10 h-[7px] w-full rounded-full' />;
   }
 
   return (
-    <div className='border-border flex h-6 w-full overflow-hidden border'>
+    <div className='flex h-[7px] w-full overflow-hidden rounded-full'>
       {segments.map((segment, index) => (
         <div
           key={`${segment.status}-${index}`}

--- a/src/features/projects/hooks/useProgressBar.ts
+++ b/src/features/projects/hooks/useProgressBar.ts
@@ -1,12 +1,9 @@
 import { useCallback, useMemo } from 'react';
 
-import { type WorkflowStep } from '@/lib/types';
+import { ChapterAssignmentStatus, type WorkflowStep } from '@/lib/types';
 
 interface ColorInfo {
   color: string;
-  opacity: number;
-  rgba: string;
-  percentage: number;
   displayName: string;
 }
 
@@ -16,33 +13,78 @@ interface ProgressSegment {
   count: number;
   widthPercentage: number;
   color: string;
-  opacity: number;
 }
+
+interface LegendItem {
+  key: string;
+  color: string;
+  displayName: string;
+}
+
+const PHASE_COLORS: Partial<Record<ChapterAssignmentStatus, string>> = {
+  [ChapterAssignmentStatus.NOT_STARTED]: 'var(--workflow-not-started)',
+  [ChapterAssignmentStatus.DRAFT]: 'var(--workflow-drafting)',
+  [ChapterAssignmentStatus.PEER_CHECK]: 'var(--workflow-peer-check)',
+  [ChapterAssignmentStatus.COMMUNITY_REVIEW]: 'var(--workflow-community-review)',
+  [ChapterAssignmentStatus.COMPLETE]: 'var(--workflow-complete)',
+};
+
+// Display names for the bar/legend. Kept separate from each step's own
+// `label` so that multiple advanced-check sub-stages (linguist check,
+// theological check, consultant check, etc.) collapse into a single
+// "Advanced Check" entry instead of one row per configured step.
+const PHASE_DISPLAY_NAMES: Partial<Record<ChapterAssignmentStatus, string>> = {
+  [ChapterAssignmentStatus.NOT_STARTED]: 'Not Started',
+  [ChapterAssignmentStatus.DRAFT]: 'Drafting',
+  [ChapterAssignmentStatus.PEER_CHECK]: 'Peer Check',
+  [ChapterAssignmentStatus.COMMUNITY_REVIEW]: 'Community Review',
+  [ChapterAssignmentStatus.COMPLETE]: 'Complete',
+};
+
+const ADVANCED_CHECK_COLOR = 'var(--workflow-advanced-check)';
+const ADVANCED_CHECK_KEY = 'advanced_check';
+const ADVANCED_CHECK_LABEL = 'Advanced Check';
+const getPhaseKey = (stepId: string): string =>
+  stepId in PHASE_COLORS ? stepId : ADVANCED_CHECK_KEY;
+
+const getPhaseColor = (stepId: string): string =>
+  PHASE_COLORS[stepId as ChapterAssignmentStatus] ?? ADVANCED_CHECK_COLOR;
+
+const getPhaseDisplayName = (stepId: string, fallbackLabel: string): string =>
+  PHASE_DISPLAY_NAMES[stepId as ChapterAssignmentStatus] ??
+  (getPhaseKey(stepId) === ADVANCED_CHECK_KEY ? ADVANCED_CHECK_LABEL : fallbackLabel);
 
 const useProgressBar = (workflowConfig: WorkflowStep[] = []) => {
   const colors = useMemo(() => {
-    const totalSteps = workflowConfig.length;
     const colorMap: Record<string, ColorInfo> = {};
-    const minOpacity = 0.1;
-    const maxOpacity = 1.0;
-    const opacityRange = maxOpacity - minOpacity;
-    const denominator = Math.max(totalSteps - 1, 1);
-    const increment = opacityRange / denominator;
 
-    workflowConfig.forEach((step, index) => {
-      const opacity = minOpacity + increment * index;
-      const percentage = Math.round(opacity * 100);
-
+    workflowConfig.forEach(step => {
       colorMap[step.id] = {
-        color: 'var(--primary)',
-        opacity,
-        rgba: `color-mix(in srgb, var(--primary) ${percentage}%, transparent)`,
-        percentage,
-        displayName: step.label,
+        color: getPhaseColor(step.id),
+        displayName: getPhaseDisplayName(step.id, step.label),
       };
     });
 
     return colorMap;
+  }, [workflowConfig]);
+
+  const legendItems = useMemo<LegendItem[]>(() => {
+    const seenKeys = new Set<string>();
+    const items: LegendItem[] = [];
+
+    [...workflowConfig].reverse().forEach(step => {
+      const key = getPhaseKey(step.id);
+      if (seenKeys.has(key)) return;
+      seenKeys.add(key);
+
+      items.push({
+        key,
+        color: getPhaseColor(step.id),
+        displayName: getPhaseDisplayName(step.id, step.label),
+      });
+    });
+
+    return items;
   }, [workflowConfig]);
 
   const calculateProgressSegments = useCallback(
@@ -67,8 +109,7 @@ const useProgressBar = (workflowConfig: WorkflowStep[] = []) => {
             displayName: stepColor.displayName,
             count,
             widthPercentage,
-            color: stepColor.rgba,
-            opacity: stepColor.opacity,
+            color: stepColor.color,
           };
         })
         .filter((segment): segment is ProgressSegment => segment.count > 0);
@@ -78,6 +119,7 @@ const useProgressBar = (workflowConfig: WorkflowStep[] = []) => {
 
   return {
     colors,
+    legendItems,
     calculateProgressSegments,
   };
 };

--- a/src/index.css
+++ b/src/index.css
@@ -102,6 +102,12 @@
   --color-hover: var(--hover);
   --color-card-hover: var(--card-hover);
   --color-popover-hover: var(--popover-hover);
+  --color-workflow-not-started: var(--workflow-not-started);
+  --color-workflow-drafting: var(--workflow-drafting);
+  --color-workflow-peer-check: var(--workflow-peer-check);
+  --color-workflow-community-review: var(--workflow-community-review);
+  --color-workflow-advanced-check: var(--workflow-advanced-check);
+  --color-workflow-complete: var(--workflow-complete);
 }
 
 :root {
@@ -163,6 +169,12 @@
   --chart-3: #17c964; /* Green */
   --chart-4: #f5a524; /* Amber */
   --chart-5: #ef4444; /* Red */
+  --workflow-not-started: #e5e7eb;
+  --workflow-drafting: #fde047;
+  --workflow-peer-check: #ea580c;
+  --workflow-community-review: #9333ea;
+  --workflow-advanced-check: #1d9bf0;
+  --workflow-complete: #16a34a;
 
   --font-sans:
     'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
@@ -257,6 +269,12 @@
   --chart-5: #f87171; /* Red */
   --scrollbar-track: #202630;
   --scrollbar-thumb: #9da6b5;
+  --workflow-not-started: #e5e7eb;
+  --workflow-drafting: #fde047;
+  --workflow-peer-check: #ea580c;
+  --workflow-community-review: #9333ea;
+  --workflow-advanced-check: #1d9bf0;
+  --workflow-complete: #16a34a;
 }
 
 @layer base {

--- a/src/index.css
+++ b/src/index.css
@@ -102,12 +102,6 @@
   --color-hover: var(--hover);
   --color-card-hover: var(--card-hover);
   --color-popover-hover: var(--popover-hover);
-  --color-workflow-not-started: var(--workflow-not-started);
-  --color-workflow-drafting: var(--workflow-drafting);
-  --color-workflow-peer-check: var(--workflow-peer-check);
-  --color-workflow-community-review: var(--workflow-community-review);
-  --color-workflow-advanced-check: var(--workflow-advanced-check);
-  --color-workflow-complete: var(--workflow-complete);
 }
 
 :root {

--- a/src/index.css
+++ b/src/index.css
@@ -163,7 +163,7 @@
   --chart-3: #17c964; /* Green */
   --chart-4: #f5a524; /* Amber */
   --chart-5: #ef4444; /* Red */
-  --workflow-not-started: #e5e7eb;
+  --workflow-not-started: #c4cad6;
   --workflow-drafting: #fde047;
   --workflow-peer-check: #ea580c;
   --workflow-community-review: #9333ea;
@@ -263,7 +263,7 @@
   --chart-5: #f87171; /* Red */
   --scrollbar-track: #202630;
   --scrollbar-thumb: #9da6b5;
-  --workflow-not-started: #e5e7eb;
+  --workflow-not-started: #c4cad6;
   --workflow-drafting: #fde047;
   --workflow-peer-check: #ea580c;
   --workflow-community-review: #9333ea;


### PR DESCRIPTION
Changes 
## Functional Requirements

### Progress Bar Dimensions

- The progress bar renders at 7px height.

### Progress Bar Segment Colors

- The Unstarted segment renders in light gray (`#e5e7eb`).
- The Drafting segment renders in yellow (`#FDE047`).
- The Peer Check segment renders in orange (`#EA580C`).
- The Community Review segment renders in purple (`#9333EA`).
- All Advanced Check stage segments render in light blue (`#1D9BF0`), regardless of how many distinct advanced check types the org uses.
- The Complete segment renders in green (`#16A34A`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced workflow progress indicators with updated color mapping and stage/phase labels.
  * Improved the progress bar legend to display phase-based names with matching color swatches.

* **Style**
  * Refreshed progress bar rendering, including slimmer, rounded empty-state visuals.
  * Updated workflow-state theme colors via new CSS variables for both light and dark modes.

* **Bug Fixes**
  * Improved legend and progress-bar consistency by rendering legend entries directly from the new phase-based data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->