### PR TITLE
adding connectivity profile to  metadata box

### DIFF
--- a/src/features/projects/components/ProjectDetailPage.tsx
+++ b/src/features/projects/components/ProjectDetailPage.tsx
@@ -28,7 +28,7 @@ import { useProjectUnitBooks } from '@/features/projects/hooks/useProjectUnitBoo
 import { useProjectUsers } from '@/features/projects/hooks/useProjectUsers';
 import { useAssignChapters, useChapterAssignments } from '@/hooks/useChapterAssignment';
 import { useUsers } from '@/hooks/useUsers';
-import { getStatusDisplay } from '@/lib/formatters';
+import { getConnectivityProfileDisplay, getStatusDisplay } from '@/lib/formatters';
 import { Logger } from '@/lib/services/logger';
 import {
   ChapterAssignmentStatus,
@@ -50,6 +50,7 @@ interface ProjectDetailPageProps {
   projectSourceLanguageName: string;
   projectTargetLanguageName: string;
   projectSource: string;
+  projectConnectivityProfile?: string | null;
   projectChapterStatusCounts: ChapterStatusCounts;
   projectWorkflowConfig: WorkflowStep[];
   isAddUserOpen?: boolean;
@@ -219,6 +220,7 @@ export const ProjectDetailPage: React.FC<ProjectDetailPageProps> = ({
   projectSourceLanguageName,
   projectTargetLanguageName,
   projectSource,
+  projectConnectivityProfile,
   projectChapterStatusCounts,
   projectWorkflowConfig,
   isAddUserOpen = false,
@@ -479,6 +481,11 @@ export const ProjectDetailPage: React.FC<ProjectDetailPageProps> = ({
                 <label className='text-base font-bold'>Source Bible</label>
                 <p className='text-base font-medium text-gray-600 dark:text-gray-400'>
                   {projectSource}
+                </p>
+
+                <label className='text-base font-bold'>Connectivity Profile</label>
+                <p className='text-base font-medium text-gray-600 dark:text-gray-400'>
+                  {getConnectivityProfileDisplay(projectConnectivityProfile)}
                 </p>
               </div>
               <CardProgressBar

--- a/src/features/projects/components/ProjectDetailWrapper.tsx
+++ b/src/features/projects/components/ProjectDetailWrapper.tsx
@@ -115,6 +115,7 @@ export const ProjectDetailWrapper: React.FC = () => {
       <ProjectDetailPage
         isAddUserOpen={modal === 'add'}
         projectChapterStatusCounts={project.chapterStatusCounts}
+        projectConnectivityProfile={project.metadata.connectivityProfile}
         projectId={project.id}
         projectSource={project.sourceName}
         projectSourceLanguageName={project.sourceLanguageName}

--- a/src/features/projects/hooks/useProjectDetails.ts
+++ b/src/features/projects/hooks/useProjectDetails.ts
@@ -3,6 +3,9 @@ import { useQuery } from '@tanstack/react-query';
 import { config } from '@/lib/config';
 import { type ChapterStatusCounts, type WorkflowStep } from '@/lib/types';
 
+export interface ProjectMetadata {
+  connectivityProfile?: string;
+}
 export interface ProjectDetails {
   id: number;
   name: string;
@@ -11,7 +14,7 @@ export interface ProjectDetails {
   createdBy: number | null;
   createdAt: string | null;
   updatedAt: string | null;
-  metadata: string;
+  metadata: ProjectMetadata;
   sourceLanguageName: string;
   targetLanguageName: string;
   sourceName: string;

--- a/src/lib/formatters/index.ts
+++ b/src/lib/formatters/index.ts
@@ -1,5 +1,17 @@
-import { type ChapterAssignmentStatus, ChapterAssignmentStatusDisplay } from '@/lib/types';
+import {
+  ChapterAssignmentStatusDisplay,
+  ConnectivityProfileDisplay,
+  type ChapterAssignmentStatus,
+  type ConnectivityProfile,
+} from '@/lib/types';
 
 export const getStatusDisplay = (status: ChapterAssignmentStatus): string => {
   return ChapterAssignmentStatusDisplay[status] || status;
+};
+
+export const getConnectivityProfileDisplay = (value?: string | null): string => {
+  if (value && value in ConnectivityProfileDisplay) {
+    return ConnectivityProfileDisplay[value as ConnectivityProfile];
+  }
+  return ConnectivityProfileDisplay.rarely_connected;
 };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -286,3 +286,11 @@ export const CHAPTER_STATUS_ORDER: ChapterAssignmentStatus[] = [
 export type SortOption = 'recent' | 'title' | 'targetLanguage';
 
 export type StatusFilter = 'all' | 'potentially_stalled' | 'not_assigned';
+
+export type ConnectivityProfile = 'usually_connected' | 'sometimes_connected' | 'rarely_connected';
+
+export const ConnectivityProfileDisplay: Record<ConnectivityProfile, string> = {
+  usually_connected: 'Usually Connected',
+  sometimes_connected: 'Sometimes Connected',
+  rarely_connected: 'Rarely Connected',
+};


### PR DESCRIPTION
following things are done in this task -

Project Metadata Box

- Add a "Connectivity Profile" row to the project metadata box.
- Display the project's stored profile value: "Usually Connected", "Sometimes Connected", or "Rarely Connected".
- If no profile was set at project creation, display "Rarely Connected" (the effective default).
- The field is read-only; no edit control is shown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project details now show a **Connectivity Profile** value on the project detail page.
  * Added human-friendly labels for connectivity profiles, with a default display when no value is available.

* **Bug Fixes**
  * Project metadata is now handled in a more structured way, improving how project details are displayed and passed through the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->