### PR TITLE
Fix Add Project User Dialog Overflow When Multiple Users Selected

### DIFF
--- a/src/components/UserMultiSelect.tsx
+++ b/src/components/UserMultiSelect.tsx
@@ -13,7 +13,76 @@ interface UserMultiSelectProps {
   isLoading?: boolean;
   disabled?: boolean;
   placeholder?: string;
-  maxVisibleNames?: number;
+}
+
+// Chip layout constants (must match UserChip CSS exactly)
+// px-2 = 8px left + 8px right, gap-1 = 4px between chips
+// rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium
+const CHIP_PADDING_X = 16; // px-2 on both sides = 8+8
+const CHIP_MAX_CONTENT = 120; // max-w-[120px] minus padding = capped text width
+const GAP = 4; // gap-1
+const CHEVRON_W = 32; // ml-2 + w-4 icon
+const TRIGGER_PADDING_X = 24; // px-3 on both sides = 12+12
+const BADGE_PADDING_X = 16; // px-2 both sides
+const BADGE_MIN_W = 28; // minimum width for "+1"
+
+let canvasCtx: CanvasRenderingContext2D | null = null;
+
+/**
+ * Measures text width using an offscreen canvas — zero DOM impact,
+ * works at any viewport size, no reflow triggered.
+ */
+function measureTextWidth(text: string, font: string): number {
+  if (!canvasCtx) {
+    const canvas = document.createElement('canvas');
+    canvasCtx = canvas.getContext('2d');
+  }
+  if (!canvasCtx) return 0;
+  canvasCtx.font = font;
+  return canvasCtx.measureText(text).width;
+}
+
+function chipWidth(label: string, font: string): number {
+  const textW = Math.min(measureTextWidth(label, font), CHIP_MAX_CONTENT);
+  return Math.ceil(textW) + CHIP_PADDING_X;
+}
+
+function badgeWidth(count: number, font: string): number {
+  const textW = measureTextWidth(`+${count}`, font);
+  return Math.max(BADGE_MIN_W, Math.ceil(textW) + BADGE_PADDING_X);
+}
+
+function computeVisibleCount(labels: string[], availableWidth: number, font: string): number {
+  if (labels.length === 0) return 0;
+
+  const chipWidths = labels.map(l => chipWidth(l, font));
+  let usedWidth = 0;
+  let count = 0;
+
+  for (let i = 0; i < chipWidths.length; i++) {
+    const isLast = i === chipWidths.length - 1;
+    const gap = i === 0 ? 0 : GAP;
+    // Only reserve badge space when this is NOT the last chip
+    const reserve = isLast ? 0 : GAP + badgeWidth(chipWidths.length - i - 1, font);
+    const needed = gap + chipWidths[i] + reserve;
+
+    if (usedWidth + needed <= availableWidth) {
+      usedWidth += gap + chipWidths[i];
+      count++;
+    } else {
+      break;
+    }
+  }
+
+  return Math.max(1, count);
+}
+
+function UserChip({ label }: { label: string }) {
+  return (
+    <span className='bg-primary/10 inline-flex max-w-[120px] shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-medium'>
+      <span className='truncate'>{label}</span>
+    </span>
+  );
 }
 
 export function UserMultiSelect({
@@ -23,25 +92,34 @@ export function UserMultiSelect({
   isLoading = false,
   disabled = false,
   placeholder = 'Select user(s)',
-  maxVisibleNames = 3,
 }: UserMultiSelectProps) {
   const [open, setOpen] = useState(false);
-
   const wrapperRef = useRef<HTMLDivElement>(null);
-  const [wrapperWidth, setWrapperWidth] = useState<number>(0);
+  const [availableWidth, setAvailableWidth] = useState(0);
+
+  // Resolve the font once from the wrapper element so canvas uses the real font
+  const [chipFont, setChipFont] = useState('500 12px ui-sans-serif');
 
   useEffect(() => {
-    const update = () => {
-      if (wrapperRef.current) {
-        setWrapperWidth(wrapperRef.current.getBoundingClientRect().width);
-      }
+    const el = wrapperRef.current;
+    if (!el) return;
+
+    const updateWidth = () => {
+      const w = el.getBoundingClientRect().width;
+      setAvailableWidth(w - TRIGGER_PADDING_X - CHEVRON_W);
     };
-    update();
 
-    const ro = new ResizeObserver(update);
-    if (wrapperRef.current) ro.observe(wrapperRef.current);
+    // Resolve font from computed styles (text-xs font-medium = 12px 500)
+    const style = window.getComputedStyle(el);
+    const size = '12px';
+    const family = style.fontFamily || 'ui-sans-serif, system-ui, sans-serif';
+    setChipFont(`500 ${size} ${family}`);
 
-    return () => ro.disconnect(); // ResizeObserver alone covers both cases
+    updateWidth();
+
+    const ro = new ResizeObserver(updateWidth);
+    ro.observe(el);
+    return () => ro.disconnect();
   }, []);
 
   const sortedUsers = useMemo(
@@ -54,12 +132,17 @@ export function UserMultiSelect({
     [value, users]
   );
 
-  const displayText =
-    selectedLabels.length === 0
-      ? placeholder
-      : selectedLabels.length <= maxVisibleNames
-        ? selectedLabels.join(', ')
-        : `${selectedLabels.slice(0, maxVisibleNames).join(', ')} +${selectedLabels.length - maxVisibleNames} more`;
+  // Pure computation — no DOM involvement
+  const visibleCount = useMemo(
+    () =>
+      availableWidth > 0
+        ? computeVisibleCount(selectedLabels, availableWidth, chipFont)
+        : selectedLabels.length,
+    [selectedLabels, availableWidth, chipFont]
+  );
+
+  const chipsToShow = selectedLabels.slice(0, visibleCount);
+  const overflowCount = selectedLabels.length - visibleCount;
 
   const toggleUser = (userId: number) => {
     if (disabled || isLoading) return;
@@ -69,7 +152,7 @@ export function UserMultiSelect({
   if (isLoading) {
     return (
       <div ref={wrapperRef} className='w-full'>
-        <div className='text-muted-foreground box-border flex w-full cursor-not-allowed items-center justify-between rounded-md border px-3 py-2 text-left text-sm'>
+        <div className='text-muted-foreground box-border flex w-full cursor-not-allowed items-center justify-between rounded-md border px-3 py-2 text-sm'>
           <div className='flex items-center gap-2'>
             <Loader2 className='h-4 w-4 animate-spin' />
             <span>Loading users...</span>
@@ -83,7 +166,7 @@ export function UserMultiSelect({
   if (disabled || users.length === 0) {
     return (
       <div ref={wrapperRef} className='w-full'>
-        <div className='text-muted-foreground box-border flex w-full cursor-not-allowed items-center justify-between rounded-md border px-3 py-2 text-left text-sm'>
+        <div className='text-muted-foreground box-border flex w-full cursor-not-allowed items-center justify-between rounded-md border px-3 py-2 text-sm'>
           <span className='truncate'>
             {users.length === 0 ? 'All users already added' : placeholder}
           </span>
@@ -97,11 +180,22 @@ export function UserMultiSelect({
     <div ref={wrapperRef} className='w-full'>
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger className='box-border flex w-full items-center justify-between rounded-md border px-3 py-2 text-left text-sm hover:bg-gray-50 dark:hover:bg-gray-800'>
-          <span
-            className={selectedLabels.length === 0 ? 'text-muted-foreground truncate' : 'truncate'}
-          >
-            {displayText}
-          </span>
+          <div className='flex min-w-0 flex-1 items-center gap-1 overflow-hidden'>
+            {selectedLabels.length === 0 ? (
+              <span className='text-muted-foreground truncate'>{placeholder}</span>
+            ) : (
+              <>
+                {chipsToShow.map(label => (
+                  <UserChip key={label} label={label} />
+                ))}
+                {overflowCount > 0 && (
+                  <span className='bg-muted text-muted-foreground inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-medium'>
+                    +{overflowCount}
+                  </span>
+                )}
+              </>
+            )}
+          </div>
           <ChevronDown className='ml-2 h-4 w-4 shrink-0' />
         </PopoverTrigger>
 
@@ -110,7 +204,10 @@ export function UserMultiSelect({
           className='text-popover-foreground pointer-events-auto rounded-md border p-0 shadow-md'
           side='bottom'
           style={{
-            width: wrapperWidth ? `${Math.round(wrapperWidth)}px` : undefined,
+            width:
+              availableWidth > 0
+                ? `${Math.round(availableWidth + TRIGGER_PADDING_X + CHEVRON_W)}px`
+                : undefined,
             boxSizing: 'border-box',
           }}
           onCloseAutoFocus={e => e.preventDefault()}


### PR DESCRIPTION
Fix Add Project User Dialog Overflow When Multiple Users Are Selected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Selected users are now shown as responsive chips that adapt to the available space.
  * An overflow badge now summarizes hidden selections with a “+N” indicator.

* **Bug Fixes**
  * Improved selection display so long names and smaller containers no longer rely on a fixed visible-item limit.
  * Loading and disabled states now align better with the updated trigger layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->