### PR TITLE
Update Advanced Check Tooltip with Sub-Check Breakdown

### DIFF
--- a/src/features/projects/components/ProjectDetailPage.tsx
+++ b/src/features/projects/components/ProjectDetailPage.tsx
@@ -70,7 +70,7 @@ const CardProgressBar: React.FC<{
   return (
     <div className='space-y-2'>
       <TooltipProvider delayDuration={100}>
-        <div className='flex h-[7px] w-full overflow-hidden rounded-full'>
+        <div className='flex h-[10px] w-full overflow-hidden rounded-full'>
           {segments.length === 0 ? (
             <div className='bg-primary/10 h-full w-full' />
           ) : (
@@ -89,7 +89,17 @@ const CardProgressBar: React.FC<{
                   className='bg-popover text-popover-foreground border-border rounded-md border px-2.5 py-1 text-xs font-semibold shadow-md'
                   side='top'
                 >
-                  {Math.round(segment.widthPercentage)}%
+                  {segment.subSegments ? (
+                    <div className='space-y-0.5'>
+                      {segment.subSegments.map(sub => (
+                        <div key={sub.label}>
+                          {sub.label}: {Math.round(sub.percentage)}%
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    `${segment.displayName}: ${Math.round(segment.widthPercentage)}%`
+                  )}
                 </TooltipContent>
               </Tooltip>
             ))

--- a/src/features/projects/components/ProjectDetailPage.tsx
+++ b/src/features/projects/components/ProjectDetailPage.tsx
@@ -93,7 +93,7 @@ const CardProgressBar: React.FC<{
                     <div className='space-y-0.5'>
                       {segment.subSegments.map(sub => (
                         <div key={sub.label}>
-                          {sub.label}: {Math.round(sub.percentage)}%
+                          {sub.label}: {sub.percentage}%
                         </div>
                       ))}
                     </div>

--- a/src/features/projects/hooks/useProgressBar.ts
+++ b/src/features/projects/hooks/useProgressBar.ts
@@ -1,10 +1,20 @@
 import { useCallback, useMemo } from 'react';
 
-import { ChapterAssignmentStatus, type WorkflowStep } from '@/lib/types';
+import {
+  ADVANCED_CHECK_SUB_LABELS,
+  ADVANCED_CHECK_SUB_STATUSES,
+  ChapterAssignmentStatus,
+  type WorkflowStep,
+} from '@/lib/types';
 
 interface ColorInfo {
   color: string;
   displayName: string;
+}
+
+interface ProgressSubSegment {
+  label: string;
+  percentage: number;
 }
 
 interface ProgressSegment {
@@ -13,6 +23,7 @@ interface ProgressSegment {
   count: number;
   widthPercentage: number;
   color: string;
+  subSegments?: ProgressSubSegment[];
 }
 
 interface LegendItem {
@@ -32,7 +43,7 @@ const PHASE_COLORS: Partial<Record<ChapterAssignmentStatus, string>> = {
 // Display names for the bar/legend. Kept separate from each step's own
 // `label` so that multiple advanced-check sub-stages (linguist check,
 // theological check, consultant check, etc.) collapse into a single
-// "Advanced Check" entry instead of one row per configured step.
+// "Advanced Checks" entry instead of one row per configured step.
 const PHASE_DISPLAY_NAMES: Partial<Record<ChapterAssignmentStatus, string>> = {
   [ChapterAssignmentStatus.NOT_STARTED]: 'Not Started',
   [ChapterAssignmentStatus.DRAFT]: 'Drafting',
@@ -43,7 +54,7 @@ const PHASE_DISPLAY_NAMES: Partial<Record<ChapterAssignmentStatus, string>> = {
 
 const ADVANCED_CHECK_COLOR = 'var(--workflow-advanced-check)';
 const ADVANCED_CHECK_KEY = 'advanced_check';
-const ADVANCED_CHECK_LABEL = 'Advanced Check';
+const ADVANCED_CHECK_LABEL = 'Advanced Checks';
 const getPhaseKey = (stepId: string): string =>
   stepId in PHASE_COLORS ? stepId : ADVANCED_CHECK_KEY;
 
@@ -97,22 +108,36 @@ const useProgressBar = (workflowConfig: WorkflowStep[] = []) => {
       if (totalChapters === 0) return [];
 
       const reversedConfig = [...workflowConfig].reverse();
+      const segmentsByKey = new Map<string, ProgressSegment>();
 
-      return reversedConfig
-        .map(step => {
-          const count = chapterStatusCounts[step.id] ?? 0;
-          const widthPercentage = (count / totalChapters) * 100;
-          const stepColor = colors[step.id];
+      reversedConfig.forEach(step => {
+        const key = getPhaseKey(step.id);
+        const count = chapterStatusCounts[step.id] ?? 0;
+        const stepColor = colors[step.id];
 
-          return {
-            status: step.id,
-            displayName: stepColor.displayName,
-            count,
-            widthPercentage,
-            color: stepColor.color,
-          };
-        })
-        .filter((segment): segment is ProgressSegment => segment.count > 0);
+        const existing = segmentsByKey.get(key);
+        if (existing) {
+          existing.count += count;
+          existing.widthPercentage = (existing.count / totalChapters) * 100;
+          return;
+        }
+        segmentsByKey.set(key, {
+          status: key,
+          displayName: stepColor.displayName,
+          count,
+          widthPercentage: (count / totalChapters) * 100,
+          color: stepColor.color,
+        });
+      });
+      const advancedSegment = segmentsByKey.get(ADVANCED_CHECK_KEY);
+      if (advancedSegment) {
+        advancedSegment.subSegments = ADVANCED_CHECK_SUB_STATUSES.map(subStatus => ({
+          label: ADVANCED_CHECK_SUB_LABELS[subStatus] ?? subStatus,
+          percentage: ((chapterStatusCounts[subStatus] ?? 0) / totalChapters) * 100,
+        }));
+      }
+
+      return Array.from(segmentsByKey.values()).filter(segment => segment.count > 0);
     },
     [workflowConfig, colors]
   );

--- a/src/features/projects/hooks/useProgressBar.ts
+++ b/src/features/projects/hooks/useProgressBar.ts
@@ -65,6 +65,21 @@ const getPhaseDisplayName = (stepId: string, fallbackLabel: string): string =>
   PHASE_DISPLAY_NAMES[stepId as ChapterAssignmentStatus] ??
   (getPhaseKey(stepId) === ADVANCED_CHECK_KEY ? ADVANCED_CHECK_LABEL : fallbackLabel);
 
+const distributeRoundedPercentages = (rawValues: number[], targetTotal: number): number[] => {
+  const floors = rawValues.map(v => Math.floor(v));
+  const remainder = targetTotal - floors.reduce((sum, v) => sum + v, 0);
+
+  const byFraction = rawValues
+    .map((v, i) => ({ i, frac: v - Math.floor(v) }))
+    .sort((a, b) => b.frac - a.frac);
+
+  const result = [...floors];
+  for (let k = 0; k < remainder && k < byFraction.length; k++) {
+    result[byFraction[k].i] += 1;
+  }
+  return result;
+};
+
 const useProgressBar = (workflowConfig: WorkflowStep[] = []) => {
   const colors = useMemo(() => {
     const colorMap: Record<string, ColorInfo> = {};
@@ -129,11 +144,31 @@ const useProgressBar = (workflowConfig: WorkflowStep[] = []) => {
           color: stepColor.color,
         });
       });
+
       const advancedSegment = segmentsByKey.get(ADVANCED_CHECK_KEY);
       if (advancedSegment) {
-        advancedSegment.subSegments = ADVANCED_CHECK_SUB_STATUSES.map(subStatus => ({
-          label: ADVANCED_CHECK_SUB_LABELS[subStatus] ?? subStatus,
-          percentage: ((chapterStatusCounts[subStatus] ?? 0) / totalChapters) * 100,
+        const collapsedSteps = reversedConfig.filter(
+          step => getPhaseKey(step.id) === ADVANCED_CHECK_KEY
+        );
+
+        const orderedSteps: WorkflowStep[] = [
+          ...ADVANCED_CHECK_SUB_STATUSES.map(
+            status => collapsedSteps.find(s => s.id === status) ?? { id: status, label: status }
+          ),
+          ...collapsedSteps.filter(
+            s => !ADVANCED_CHECK_SUB_STATUSES.includes(s.id as ChapterAssignmentStatus)
+          ),
+        ];
+
+        const rawPercentages = orderedSteps.map(
+          step => ((chapterStatusCounts[step.id] ?? 0) / totalChapters) * 100
+        );
+        const roundedTotal = Math.round(advancedSegment.widthPercentage);
+        const roundedPercentages = distributeRoundedPercentages(rawPercentages, roundedTotal);
+
+        advancedSegment.subSegments = orderedSteps.map((step, index) => ({
+          label: ADVANCED_CHECK_SUB_LABELS[step.id as ChapterAssignmentStatus] ?? step.label,
+          percentage: roundedPercentages[index],
         }));
       }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -314,6 +314,18 @@ export const ChapterAssignmentStatusNextAction: Partial<Record<ChapterAssignment
   [ChapterAssignmentStatus.CONSULTANT_CHECK]: 'Mark as Complete',
 };
 
+export const ADVANCED_CHECK_SUB_STATUSES: ChapterAssignmentStatus[] = [
+  ChapterAssignmentStatus.LINGUIST_CHECK,
+  ChapterAssignmentStatus.THEOLOGICAL_CHECK,
+  ChapterAssignmentStatus.CONSULTANT_CHECK,
+];
+
+export const ADVANCED_CHECK_SUB_LABELS: Partial<Record<ChapterAssignmentStatus, string>> = {
+  [ChapterAssignmentStatus.LINGUIST_CHECK]: 'Linguist Check',
+  [ChapterAssignmentStatus.THEOLOGICAL_CHECK]: 'Theologian Check',
+  [ChapterAssignmentStatus.CONSULTANT_CHECK]: 'Consultant Check',
+};
+
 export const CHAPTER_STATUS_ORDER: ChapterAssignmentStatus[] = [
   ChapterAssignmentStatus.NOT_STARTED,
   ChapterAssignmentStatus.DRAFT,


### PR DESCRIPTION
## Functional Requirements
### Progress Bar Segment

- [x] The progress bar track height is increased to 10px.
- [x] The Advanced Check segment continues to render as a single bar segment covering a % of the total progress bar width, unchanged from current behavior.
- [x] The legend continues to display a single "Advanced Checks" entry; it does not list the sub-checks individually.
- [x] Note: The pluralization of Checks in the legend which is not present now in the legend.


### Tooltip

- [x] Hovering the Advanced Check segment displays a tooltip with three lines, one per sub-check, in this order: Linguist Check, Theologian Check, Consultant Check.
- [x] Each line displays the sub-check name and its percentage, eg. Linguist Check 12%, Theologian Check 12%, Consultant Check 8%.
- [x] The tooltip does not include a title or heading identifying the lines as "Advanced Checks."
- [x] All other progress bar segments (Complete, Community Review, Peer Check, Drafting, Not Started) continue to show their existing single-line tooltip with label and percentage.
- [x] All the other checks should use the category name like "Drafting: 67%".
Notes
The three sub-check percentages must always sum to the total width of the Advanced Check segment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved project progress display with a taller progress bar for easier readability.
  * Expanded progress tooltips to show detailed sub-segment labels and rounded percentages when available.
  * Updated the “Advanced Check” label to “Advanced Checks” in the progress legend.

* **Bug Fixes**
  * Progress segments are now grouped/aggregated more consistently, producing a clearer and more accurate overview of progress across related checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->