### PR TITLE
updated project view for Layout to Stack Panels Below 1024px

### DIFF
--- a/src/features/projects/components/AssignProjectUsers.tsx
+++ b/src/features/projects/components/AssignProjectUsers.tsx
@@ -205,7 +205,6 @@ export const AssignProjectUsers: React.FC<AssignProjectUsersProps> = ({
             </Tooltip>
           </TooltipProvider>
         </div>
-
         {/*Error banner — only shown when the fetch itself failed */}
         {projectUsersError && (
           <div className='mx-3 mb-2 flex shrink-0 items-center gap-1.5 text-sm text-red-500'>
@@ -213,25 +212,19 @@ export const AssignProjectUsers: React.FC<AssignProjectUsersProps> = ({
             <span>Error: Loading users failed.</span>
           </div>
         )}
-
         {error && (
           <div className='mx-3 mb-2 flex shrink-0 items-center gap-1.5 text-sm text-red-500'>
             <TriangleAlert className='h-4 w-4 shrink-0' />
             <span>{error}</span>
           </div>
         )}
-
         {/* Users table */}
         <div
           className={`flex min-h-0 flex-1 flex-col overflow-hidden rounded-none border-0 border-t lg:flex-none lg:rounded-lg lg:border lg:shadow-sm ${
             error || projectUsersError ? 'lg:max-h-[165px]' : 'lg:max-h-[188px]'
           }`}
         >
-          <div
-            className={`min-h-0 flex-1 overflow-y-auto rounded-lg lg:flex-none ${
-              error || projectUsersError ? 'lg:max-h-[165px]' : 'lg:max-h-[188px]'
-            }`}
-          >
+          <div className='min-h-0 flex-1 overflow-y-auto rounded-lg'>
             <Table>
               <TableHeader className='sticky top-0 z-10'>
                 <TableRow className='hover:bg-transparent'>

--- a/src/features/projects/components/AssignProjectUsers.tsx
+++ b/src/features/projects/components/AssignProjectUsers.tsx
@@ -220,7 +220,7 @@ export const AssignProjectUsers: React.FC<AssignProjectUsersProps> = ({
         )}
         {/* Users table */}
         <div
-          className={`flex min-h-0 flex-1 flex-col overflow-hidden rounded-none border-0 border-t lg:flex-none lg:rounded-lg lg:border lg:shadow-sm ${
+          className={`flex min-h-0 flex-1 flex-col overflow-hidden rounded-none border-0 border-t lg:mx-3 lg:flex-none lg:rounded-lg lg:border lg:shadow-sm ${
             error || projectUsersError ? 'lg:max-h-[165px]' : 'lg:max-h-[188px]'
           }`}
         >

--- a/src/features/projects/components/AssignProjectUsers.tsx
+++ b/src/features/projects/components/AssignProjectUsers.tsx
@@ -3,7 +3,6 @@ import { useCallback, useMemo, useState } from 'react';
 import { Loader2, Plus, Trash2, TriangleAlert } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import {
   Table,
@@ -29,6 +28,7 @@ interface AssignProjectUsersProps {
   isAddUserOpen?: boolean;
   onAddUser?: () => void;
   onCloseAddUser?: () => void;
+  referenceHeight?: number;
 }
 
 export const AssignProjectUsers: React.FC<AssignProjectUsersProps> = ({
@@ -38,6 +38,7 @@ export const AssignProjectUsers: React.FC<AssignProjectUsersProps> = ({
   isAddUserOpen = false,
   onAddUser,
   onCloseAddUser,
+  referenceHeight,
 }) => {
   const [selectedUsersToAdd, setSelectedUsersToAdd] = useState<number[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -182,9 +183,12 @@ export const AssignProjectUsers: React.FC<AssignProjectUsersProps> = ({
 
   return (
     <>
-      <div className='flex flex-col'>
+      <div
+        className='flex flex-col overflow-hidden rounded-lg border lg:overflow-visible lg:rounded-none lg:border-0'
+        style={referenceHeight ? { height: referenceHeight } : undefined}
+      >
         {/* Title row */}
-        <div className='mb-3 flex items-center justify-between'>
+        <div className='flex shrink-0 items-center justify-between p-3 pb-3'>
           <h3 className='text-lg font-bold'>Project Users</h3>
           <TooltipProvider delayDuration={300}>
             <Tooltip>
@@ -204,37 +208,41 @@ export const AssignProjectUsers: React.FC<AssignProjectUsersProps> = ({
 
         {/*Error banner — only shown when the fetch itself failed */}
         {projectUsersError && (
-          <div className='mb-2 flex items-center gap-1.5 text-sm text-red-500'>
+          <div className='mx-3 mb-2 flex shrink-0 items-center gap-1.5 text-sm text-red-500'>
             <TriangleAlert className='h-4 w-4 shrink-0' />
             <span>Error: Loading users failed.</span>
           </div>
         )}
 
         {error && (
-          <div className='mb-2 flex items-center gap-1.5 text-sm text-red-500'>
+          <div className='mx-3 mb-2 flex shrink-0 items-center gap-1.5 text-sm text-red-500'>
             <TriangleAlert className='h-4 w-4 shrink-0' />
             <span>{error}</span>
           </div>
         )}
 
         {/* Users table */}
-        <Card>
-          <CardContent className='p-0'>
-            <div
-              className={`overflow-y-auto rounded-lg ${error || projectUsersError ? 'max-h-[165px]' : 'max-h-[188px]'}`}
-            >
-              <Table>
-                <TableHeader className='sticky top-0 z-10'>
-                  <TableRow className='hover:bg-transparent'>
-                    <TableHead className='py-2 pl-3 text-sm font-semibold'>Name</TableHead>
-                    <TableHead className='w-10 py-2 pr-3' />
-                  </TableRow>
-                </TableHeader>
-                <TableBody className='bg-background'>{renderTableBody()}</TableBody>
-              </Table>
-            </div>
-          </CardContent>
-        </Card>
+        <div
+          className={`flex min-h-0 flex-1 flex-col overflow-hidden rounded-none border-0 border-t lg:flex-none lg:rounded-lg lg:border lg:shadow-sm ${
+            error || projectUsersError ? 'lg:max-h-[165px]' : 'lg:max-h-[188px]'
+          }`}
+        >
+          <div
+            className={`min-h-0 flex-1 overflow-y-auto rounded-lg lg:flex-none ${
+              error || projectUsersError ? 'lg:max-h-[165px]' : 'lg:max-h-[188px]'
+            }`}
+          >
+            <Table>
+              <TableHeader className='sticky top-0 z-10'>
+                <TableRow className='hover:bg-transparent'>
+                  <TableHead className='py-2 pl-3 text-sm font-semibold'>Name</TableHead>
+                  <TableHead className='w-10 py-2 pr-3' />
+                </TableRow>
+              </TableHeader>
+              <TableBody className='bg-background'>{renderTableBody()}</TableBody>
+            </Table>
+          </div>
+        </div>
       </div>
 
       {/* Add Project User Dialog */}

--- a/src/features/projects/components/ChapterAssignmentsTable.tsx
+++ b/src/features/projects/components/ChapterAssignmentsTable.tsx
@@ -1,0 +1,197 @@
+import { useLayoutEffect, useRef, useState } from 'react';
+
+import { Loader2 } from 'lucide-react';
+
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { getStatusDisplay } from '@/lib/formatters';
+import {
+  type ChapterAssignmentProgress,
+  type ChapterAssignmentStatus as ChapterAssignmentStatusType,
+} from '@/lib/types';
+
+export const TruncatedTableText = ({ text }: { text: string }) => {
+  const textRef = useRef<HTMLDivElement>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useLayoutEffect(() => {
+    const checkTruncation = () => {
+      if (textRef.current) {
+        setIsTruncated(textRef.current.scrollWidth > textRef.current.clientWidth);
+      }
+    };
+
+    checkTruncation();
+    let timeoutId: NodeJS.Timeout;
+    const debouncedCheck = () => {
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(checkTruncation, 150);
+    };
+    window.addEventListener('resize', debouncedCheck);
+    return () => {
+      clearTimeout(timeoutId);
+      window.removeEventListener('resize', debouncedCheck);
+    };
+  }, [text]);
+
+  const content = (
+    <div ref={textRef} className='max-w-full cursor-default truncate' title=''>
+      {text}
+    </div>
+  );
+
+  if (!isTruncated) return content;
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>{content}</TooltipTrigger>
+        <TooltipContent
+          align='center'
+          className='bg-popover text-popover-foreground border-border rounded-md border px-4 py-2.5 text-sm font-semibold whitespace-nowrap shadow-lg'
+          side='top'
+        >
+          {text}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};
+
+interface ChapterAssignmentsTableProps {
+  assignments: ChapterAssignmentProgress[];
+  isLoading: boolean;
+  selectedBook: string;
+  isManager: boolean;
+  selectedAssignments: number[];
+  isRowActionsDisabled: boolean;
+  onRowClick: (assignment: ChapterAssignmentProgress) => void;
+  onCheckboxChange: (assignmentId: number, checked: boolean) => void;
+}
+
+export const ChapterAssignmentsTable: React.FC<ChapterAssignmentsTableProps> = ({
+  assignments,
+  isLoading,
+  selectedBook,
+  isManager,
+  selectedAssignments,
+  isRowActionsDisabled,
+  onRowClick,
+  onCheckboxChange,
+}) => {
+  const formatProgress = (completedVerses: number, totalVerses: number) =>
+    `${completedVerses} of ${totalVerses}`;
+
+  return (
+    <div className='flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border'>
+      {isLoading ? (
+        <div className='flex items-center justify-center gap-2 py-8'>
+          <Loader2 className='h-5 w-5 animate-spin text-gray-500' />
+          <span className='text-gray-500'>Loading assignments...</span>
+        </div>
+      ) : assignments.length === 0 ? (
+        <div className='flex items-center justify-center py-8'>
+          <span>
+            {selectedBook && selectedBook !== 'all'
+              ? 'No assignments found for selected book'
+              : 'No assignments found'}
+          </span>
+        </div>
+      ) : (
+        <TooltipProvider delayDuration={300}>
+          <div className='relative flex h-full flex-col overflow-y-auto'>
+            <Table className='w-full table-fixed'>
+              <TableHeader className='sticky top-0 z-10'>
+                <TableRow className='hover:bg-transparent'>
+                  <TableHead className='w-12 px-3 py-2 md:px-4 md:py-2.5 lg:px-6 lg:py-3'>
+                    <></>
+                  </TableHead>
+                  <TableHead className='text-accent-foreground px-3 py-2 text-left text-xs font-semibold tracking-wider md:px-4 md:py-2.5 md:text-sm lg:px-6 lg:py-3 lg:text-base'>
+                    Book
+                  </TableHead>
+                  <TableHead className='text-accent-foreground px-3 py-2 text-left text-xs font-semibold tracking-wider md:px-4 md:py-2.5 md:text-sm lg:px-6 lg:py-3 lg:text-base'>
+                    Chapter
+                  </TableHead>
+                  <TableHead className='text-accent-foreground px-3 py-2 text-left text-xs font-semibold tracking-wider md:px-4 md:py-2.5 md:text-sm lg:px-6 lg:py-3 lg:text-base'>
+                    Drafter
+                  </TableHead>
+                  <TableHead className='text-accent-foreground px-3 py-2 text-left text-xs font-semibold tracking-wider md:px-4 md:py-2.5 md:text-sm lg:px-6 lg:py-3 lg:text-base'>
+                    <TruncatedTableText text='Peer Checker' />
+                  </TableHead>
+                  <TableHead className='text-accent-foreground px-3 py-2 text-left text-xs font-semibold tracking-wider md:px-4 md:py-2.5 md:text-sm lg:px-6 lg:py-3 lg:text-base'>
+                    Status
+                  </TableHead>
+                  <TableHead className='text-accent-foreground px-3 py-2 text-left text-xs font-semibold tracking-wider md:px-4 md:py-2.5 md:text-sm lg:px-6 lg:py-3 lg:text-base'>
+                    Progress
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody className='divide-border divide-y'>
+                {assignments.map(assignment => (
+                  <TableRow
+                    key={assignment.assignmentId}
+                    className='align-center cursor-pointer border-b transition-colors hover:bg-gray-50 dark:hover:bg-gray-800'
+                    onClick={() => onRowClick(assignment)}
+                  >
+                    <TableCell
+                      className={`w-12 px-3 py-3 md:px-4 md:py-3.5 lg:px-6 lg:py-4 ${isManager ? 'cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700' : ''}`}
+                      onClick={e => {
+                        e.stopPropagation();
+                        if (!isRowActionsDisabled && isManager) {
+                          onCheckboxChange(
+                            assignment.assignmentId,
+                            !selectedAssignments.includes(assignment.assignmentId)
+                          );
+                        }
+                      }}
+                    >
+                      {isManager && (
+                        <Checkbox
+                          checked={selectedAssignments.includes(assignment.assignmentId)}
+                          disabled={isRowActionsDisabled}
+                          onCheckedChange={checked =>
+                            onCheckboxChange(assignment.assignmentId, !!checked)
+                          }
+                        />
+                      )}
+                    </TableCell>
+                    <TableCell className='text-popover-foreground px-3 py-3 text-xs md:px-4 md:py-3.5 md:text-sm lg:px-6 lg:py-4 lg:text-base'>
+                      <TruncatedTableText text={assignment.bookNameEng} />
+                    </TableCell>
+                    <TableCell className='text-popover-foreground px-3 py-3 text-xs whitespace-nowrap md:px-4 md:py-3.5 md:text-sm lg:px-6 lg:py-4 lg:text-base'>
+                      {assignment.chapterNumber}
+                    </TableCell>
+                    <TableCell className='text-popover-foreground px-3 py-3 text-xs md:px-4 md:py-3.5 md:text-sm lg:px-6 lg:py-4 lg:text-base'>
+                      <TruncatedTableText text={assignment.assignedUser?.displayName ?? ''} />
+                    </TableCell>
+                    <TableCell className='text-popover-foreground px-3 py-3 text-xs md:px-4 md:py-3.5 md:text-sm lg:px-6 lg:py-4 lg:text-base'>
+                      <TruncatedTableText text={assignment.peerChecker?.displayName ?? ''} />
+                    </TableCell>
+                    <TableCell className='text-popover-foreground px-3 py-3 text-xs whitespace-nowrap md:px-4 md:py-3.5 md:text-sm lg:px-6 lg:py-4 lg:text-base'>
+                      <TruncatedTableText
+                        text={getStatusDisplay(assignment.status as ChapterAssignmentStatusType)}
+                      />
+                    </TableCell>
+                    <TableCell className='text-popover-foreground px-3 py-3 text-xs md:px-4 md:py-3.5 md:text-sm lg:px-6 lg:py-4 lg:text-base'>
+                      <TruncatedTableText
+                        text={formatProgress(assignment.completedVerses, assignment.totalVerses)}
+                      />
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </TooltipProvider>
+      )}
+    </div>
+  );
+};

--- a/src/features/projects/components/ChapterAssignmentsTable.tsx
+++ b/src/features/projects/components/ChapterAssignmentsTable.tsx
@@ -64,7 +64,7 @@ export const ChapterAssignmentsTable: React.FC<ChapterAssignmentsTableProps> = (
               <TableHeader className='sticky top-0 z-10'>
                 <TableRow className='hover:bg-transparent'>
                   <TableHead className='w-12 px-3 py-2 md:px-4 md:py-2.5 lg:px-6 lg:py-3'>
-                    <></>
+                    <span className='sr-only'>Select</span>
                   </TableHead>
                   <TableHead className='text-accent-foreground px-3 py-2 text-left text-xs font-semibold tracking-wider md:px-4 md:py-2.5 md:text-sm lg:px-6 lg:py-3 lg:text-base'>
                     Book

--- a/src/features/projects/components/ChapterAssignmentsTable.tsx
+++ b/src/features/projects/components/ChapterAssignmentsTable.tsx
@@ -1,5 +1,3 @@
-import { useLayoutEffect, useRef, useState } from 'react';
-
 import { Loader2 } from 'lucide-react';
 
 import { Checkbox } from '@/components/ui/checkbox';
@@ -11,60 +9,14 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { TooltipProvider } from '@/components/ui/tooltip';
 import { getStatusDisplay } from '@/lib/formatters';
 import {
   type ChapterAssignmentProgress,
   type ChapterAssignmentStatus as ChapterAssignmentStatusType,
 } from '@/lib/types';
 
-export const TruncatedTableText = ({ text }: { text: string }) => {
-  const textRef = useRef<HTMLDivElement>(null);
-  const [isTruncated, setIsTruncated] = useState(false);
-
-  useLayoutEffect(() => {
-    const checkTruncation = () => {
-      if (textRef.current) {
-        setIsTruncated(textRef.current.scrollWidth > textRef.current.clientWidth);
-      }
-    };
-
-    checkTruncation();
-    let timeoutId: NodeJS.Timeout;
-    const debouncedCheck = () => {
-      clearTimeout(timeoutId);
-      timeoutId = setTimeout(checkTruncation, 150);
-    };
-    window.addEventListener('resize', debouncedCheck);
-    return () => {
-      clearTimeout(timeoutId);
-      window.removeEventListener('resize', debouncedCheck);
-    };
-  }, [text]);
-
-  const content = (
-    <div ref={textRef} className='max-w-full cursor-default truncate' title=''>
-      {text}
-    </div>
-  );
-
-  if (!isTruncated) return content;
-
-  return (
-    <TooltipProvider delayDuration={300}>
-      <Tooltip>
-        <TooltipTrigger asChild>{content}</TooltipTrigger>
-        <TooltipContent
-          align='center'
-          className='bg-popover text-popover-foreground border-border rounded-md border px-4 py-2.5 text-sm font-semibold whitespace-nowrap shadow-lg'
-          side='top'
-        >
-          {text}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  );
-};
+import { TruncatedTableText } from './TruncatedText';
 
 interface ChapterAssignmentsTableProps {
   assignments: ChapterAssignmentProgress[];
@@ -77,6 +29,9 @@ interface ChapterAssignmentsTableProps {
   onCheckboxChange: (assignmentId: number, checked: boolean) => void;
 }
 
+const formatProgress = (completedVerses: number, totalVerses: number): string =>
+  `${completedVerses} of ${totalVerses}`;
+
 export const ChapterAssignmentsTable: React.FC<ChapterAssignmentsTableProps> = ({
   assignments,
   isLoading,
@@ -87,9 +42,6 @@ export const ChapterAssignmentsTable: React.FC<ChapterAssignmentsTableProps> = (
   onRowClick,
   onCheckboxChange,
 }) => {
-  const formatProgress = (completedVerses: number, totalVerses: number) =>
-    `${completedVerses} of ${totalVerses}`;
-
   return (
     <div className='flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border'>
       {isLoading ? (
@@ -157,9 +109,6 @@ export const ChapterAssignmentsTable: React.FC<ChapterAssignmentsTableProps> = (
                         <Checkbox
                           checked={selectedAssignments.includes(assignment.assignmentId)}
                           disabled={isRowActionsDisabled}
-                          onCheckedChange={checked =>
-                            onCheckboxChange(assignment.assignmentId, !!checked)
-                          }
                         />
                       )}
                     </TableCell>

--- a/src/features/projects/components/ProjectDetailPage.tsx
+++ b/src/features/projects/components/ProjectDetailPage.tsx
@@ -13,7 +13,6 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { ChapterAssignmentsTable } from '@/features/projects/components/ChapterAssignmentsTable';
 import { ViewPageHeader } from '@/features/projects/components/ViewPageHeader';
 import useProgressBar from '@/features/projects/hooks/useProgressBar';
 import { useProjectUnitBooks } from '@/features/projects/hooks/useProjectUnitBooks';
@@ -35,6 +34,8 @@ import { useAppStore } from '@/store/store';
 
 import { AssignProjectUsers } from './AssignProjectUsers';
 import { AssignUsersDialog } from './AssignUsersDialog';
+import { ChapterAssignmentsTable } from './ChapterAssignmentsTable';
+import { TruncatedCardText } from './TruncatedText';
 
 interface ProjectDetailPageProps {
   projectId?: number | null;
@@ -111,57 +112,6 @@ const CardProgressBar: React.FC<{
         ))}
       </div>
     </div>
-  );
-};
-
-const TruncatedCardText = ({ text }: { text: string }) => {
-  const textRef = useRef<HTMLDivElement>(null);
-  const [isTruncated, setIsTruncated] = useState(false);
-
-  useLayoutEffect(() => {
-    const checkTruncation = () => {
-      if (textRef.current) {
-        setIsTruncated(textRef.current.scrollWidth > textRef.current.clientWidth);
-      }
-    };
-
-    checkTruncation();
-    let timeoutId: NodeJS.Timeout;
-    const debouncedCheck = () => {
-      clearTimeout(timeoutId);
-      timeoutId = setTimeout(checkTruncation, 150);
-    };
-    window.addEventListener('resize', debouncedCheck);
-    return () => {
-      clearTimeout(timeoutId);
-      window.removeEventListener('resize', debouncedCheck);
-    };
-  }, [text]);
-
-  const content = (
-    <div
-      ref={textRef}
-      className='max-w-full cursor-default truncate text-base font-medium text-gray-600 dark:text-gray-400'
-    >
-      {text}
-    </div>
-  );
-
-  if (!isTruncated) return content;
-
-  return (
-    <TooltipProvider delayDuration={300}>
-      <Tooltip>
-        <TooltipTrigger asChild>{content}</TooltipTrigger>
-        <TooltipContent
-          align='center'
-          className='bg-popover text-popover-foreground border-border max-w-[350px] rounded-md border px-4 py-2.5 text-sm font-semibold break-all shadow-lg'
-          side='bottom'
-        >
-          {text}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
   );
 };
 

--- a/src/features/projects/components/ProjectDetailPage.tsx
+++ b/src/features/projects/components/ProjectDetailPage.tsx
@@ -5,7 +5,6 @@ import { Loader2 } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
-import { Checkbox } from '@/components/ui/checkbox';
 import {
   Select,
   SelectContent,
@@ -13,22 +12,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { ChapterAssignmentsTable } from '@/features/projects/components/ChapterAssignmentsTable';
 import { ViewPageHeader } from '@/features/projects/components/ViewPageHeader';
 import useProgressBar from '@/features/projects/hooks/useProgressBar';
 import { useProjectUnitBooks } from '@/features/projects/hooks/useProjectUnitBooks';
 import { useProjectUsers } from '@/features/projects/hooks/useProjectUsers';
 import { useAssignChapters, useChapterAssignments } from '@/hooks/useChapterAssignment';
 import { useUsers } from '@/hooks/useUsers';
-import { getConnectivityProfileDisplay, getStatusDisplay } from '@/lib/formatters';
+import { getConnectivityProfileDisplay } from '@/lib/formatters';
 import { Logger } from '@/lib/services/logger';
 import {
   ChapterAssignmentStatus,
@@ -173,54 +165,6 @@ const TruncatedCardText = ({ text }: { text: string }) => {
   );
 };
 
-const TruncatedTableText = ({ text }: { text: string }) => {
-  const textRef = useRef<HTMLDivElement>(null);
-  const [isTruncated, setIsTruncated] = useState(false);
-
-  useLayoutEffect(() => {
-    const checkTruncation = () => {
-      if (textRef.current) {
-        setIsTruncated(textRef.current.scrollWidth > textRef.current.clientWidth);
-      }
-    };
-
-    checkTruncation();
-    let timeoutId: NodeJS.Timeout;
-    const debouncedCheck = () => {
-      clearTimeout(timeoutId);
-      timeoutId = setTimeout(checkTruncation, 150);
-    };
-    window.addEventListener('resize', debouncedCheck);
-    return () => {
-      clearTimeout(timeoutId);
-      window.removeEventListener('resize', debouncedCheck);
-    };
-  }, [text]);
-
-  const content = (
-    <div ref={textRef} className='max-w-full cursor-default truncate' title=''>
-      {text}
-    </div>
-  );
-
-  if (!isTruncated) return content;
-
-  return (
-    <TooltipProvider delayDuration={300}>
-      <Tooltip>
-        <TooltipTrigger asChild>{content}</TooltipTrigger>
-        <TooltipContent
-          align='center'
-          className='bg-popover text-popover-foreground border-border rounded-md border px-4 py-2.5 text-sm font-semibold whitespace-nowrap shadow-lg'
-          side='top'
-        >
-          {text}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  );
-};
-
 export const ProjectDetailPage: React.FC<ProjectDetailPageProps> = ({
   projectId,
   projectTitle,
@@ -288,6 +232,35 @@ export const ProjectDetailPage: React.FC<ProjectDetailPageProps> = ({
     [projectUsers]
   );
 
+  const detailsCardRef = useRef<HTMLDivElement>(null);
+  const [detailsHeight, setDetailsHeight] = useState<number>();
+
+  useLayoutEffect(() => {
+    const updateHeight = () => {
+      if (window.innerWidth >= 1024) {
+        setDetailsHeight(undefined);
+        return;
+      }
+
+      setDetailsHeight(detailsCardRef.current?.offsetHeight);
+    };
+
+    updateHeight();
+
+    const observer = new ResizeObserver(updateHeight);
+
+    if (detailsCardRef.current) {
+      observer.observe(detailsCardRef.current);
+    }
+
+    window.addEventListener('resize', updateHeight);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', updateHeight);
+    };
+  }, []);
+
   const assignChapterMutation = useAssignChapters(
     projectId ? projectId.toString() : '0',
     getSelectedUserFullName(selectedDrafter),
@@ -305,10 +278,6 @@ export const ProjectDetailPage: React.FC<ProjectDetailPageProps> = ({
       assignment => assignment.bookNameEng === selectedBookData.engDisplayName
     );
   }, [chapterAssignments, selectedBook, books]);
-
-  const formatProgress = useCallback((completedVerses: number, totalVerses: number) => {
-    return `${completedVerses} of ${totalVerses}`;
-  }, []);
 
   const handleChapterRowClick = useCallback(
     (assignment: ChapterAssignmentProgress) => {
@@ -453,7 +422,7 @@ export const ProjectDetailPage: React.FC<ProjectDetailPageProps> = ({
   const isDisabled = booksLoading || !books?.length || !chapterAssignments?.length;
 
   return (
-    <div className='flex h-full min-w-[750px] flex-col'>
+    <div className='mx-auto flex h-full min-w-[730px] flex-col'>
       <ViewPageHeader
         rightContent={
           <Button
@@ -470,11 +439,11 @@ export const ProjectDetailPage: React.FC<ProjectDetailPageProps> = ({
         onBack={onBack}
       />
 
-      <div className='flex flex-1 overflow-hidden md:gap-4 lg:gap-6'>
-        {/* Left Pane - Project Details + Project Users */}
-        <div className='flex w-1/4 shrink-0 flex-col gap-4'>
+      <div className='flex flex-1 flex-col gap-4 overflow-hidden lg:flex-row lg:gap-6'>
+        {/* Meta + Users Pane - side by side below 1024px, stacked column at 1024px+ */}
+        <div className='flex shrink-0 flex-row gap-4 lg:w-1/4 lg:flex-col lg:overflow-y-auto'>
           {/* Project Details Card */}
-          <Card className='h-fit'>
+          <Card ref={detailsCardRef} className='h-fit flex-1 lg:flex-none'>
             <CardContent className='space-y-4 py-4'>
               <div className='grid grid-cols-2 gap-2'>
                 <label className='text-base font-bold'>Title</label>
@@ -509,19 +478,22 @@ export const ProjectDetailPage: React.FC<ProjectDetailPageProps> = ({
 
           {/* Project Users Section - Managers only */}
           {isManager && (
-            <AssignProjectUsers
-              isAddUserOpen={isAddUserOpen}
-              projectId={projectId}
-              users={users}
-              usersLoading={usersLoading}
-              onAddUser={onAddUser}
-              onCloseAddUser={onCloseAddUser}
-            />
+            <div className='flex-1 lg:flex-none'>
+              <AssignProjectUsers
+                isAddUserOpen={isAddUserOpen}
+                projectId={projectId}
+                referenceHeight={detailsHeight}
+                users={users}
+                usersLoading={usersLoading}
+                onAddUser={onAddUser}
+                onCloseAddUser={onCloseAddUser}
+              />
+            </div>
           )}
         </div>
 
         {/* Table Section */}
-        <div className='flex w-3/4 grow flex-col overflow-hidden'>
+        <div className='flex min-h-0 w-full flex-1 flex-col lg:w-3/4 lg:grow'>
           <div className='shrink-0 pb-4 pl-[3px]'>
             <div className='flex items-center gap-3'>
               <Select value={selectedBook} onValueChange={setSelectedBook}>
@@ -559,119 +531,16 @@ export const ProjectDetailPage: React.FC<ProjectDetailPageProps> = ({
             </div>
           </div>
 
-          <div className='flex h-full flex-col overflow-hidden rounded-lg border'>
-            {assignmentsLoading ? (
-              <div className='flex items-center justify-center gap-2 py-8'>
-                <Loader2 className='h-5 w-5 animate-spin text-gray-500' />
-                <span className='text-gray-500'>Loading assignments...</span>
-              </div>
-            ) : filteredAssignments.length === 0 ? (
-              <div className='flex items-center justify-center py-8'>
-                <span>
-                  {selectedBook && selectedBook !== 'all'
-                    ? 'No assignments found for selected book'
-                    : 'No assignments found'}
-                </span>
-              </div>
-            ) : (
-              <TooltipProvider delayDuration={300}>
-                <div className='relative flex h-full flex-col overflow-y-auto'>
-                  <Table className='w-full table-fixed'>
-                    <TableHeader className='sticky top-0 z-10'>
-                      <TableRow className='hover:bg-transparent'>
-                        <TableHead className='w-12 px-3 py-2 md:px-4 md:py-2.5 lg:px-6 lg:py-3'>
-                          <></>
-                        </TableHead>
-                        <TableHead className='text-accent-foreground px-3 py-2 text-left text-xs font-semibold tracking-wider md:px-4 md:py-2.5 md:text-sm lg:px-6 lg:py-3 lg:text-base'>
-                          Book
-                        </TableHead>
-                        <TableHead className='text-accent-foreground px-3 py-2 text-left text-xs font-semibold tracking-wider md:px-4 md:py-2.5 md:text-sm lg:px-6 lg:py-3 lg:text-base'>
-                          Chapter
-                        </TableHead>
-                        <TableHead className='text-accent-foreground px-3 py-2 text-left text-xs font-semibold tracking-wider md:px-4 md:py-2.5 md:text-sm lg:px-6 lg:py-3 lg:text-base'>
-                          Drafter
-                        </TableHead>
-                        <TableHead className='text-accent-foreground px-3 py-2 text-left text-xs font-semibold tracking-wider md:px-4 md:py-2.5 md:text-sm lg:px-6 lg:py-3 lg:text-base'>
-                          <TruncatedTableText text='Peer Checker' />
-                        </TableHead>
-                        <TableHead className='text-accent-foreground px-3 py-2 text-left text-xs font-semibold tracking-wider md:px-4 md:py-2.5 md:text-sm lg:px-6 lg:py-3 lg:text-base'>
-                          Status
-                        </TableHead>
-                        <TableHead className='text-accent-foreground px-3 py-2 text-left text-xs font-semibold tracking-wider md:px-4 md:py-2.5 md:text-sm lg:px-6 lg:py-3 lg:text-base'>
-                          Progress
-                        </TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody className='divide-border divide-y'>
-                      {filteredAssignments.map(assignment => {
-                        return (
-                          <TableRow
-                            key={assignment.assignmentId}
-                            className='align-center cursor-pointer border-b transition-colors hover:bg-gray-50 dark:hover:bg-gray-800'
-                            onClick={() => handleChapterRowClick(assignment)}
-                          >
-                            <TableCell
-                              className={`w-12 px-3 py-3 md:px-4 md:py-3.5 lg:px-6 lg:py-4 ${isManager ? 'cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700' : ''}`}
-                              onClick={e => {
-                                e.stopPropagation();
-                                if (!isLoadingData && isManager) {
-                                  handleCheckboxChange(
-                                    assignment.assignmentId,
-                                    !selectedAssignments.includes(assignment.assignmentId)
-                                  );
-                                }
-                              }}
-                            >
-                              {isManager && (
-                                <Checkbox
-                                  checked={selectedAssignments.includes(assignment.assignmentId)}
-                                  disabled={isLoadingData}
-                                  onCheckedChange={checked =>
-                                    handleCheckboxChange(assignment.assignmentId, !!checked)
-                                  }
-                                />
-                              )}
-                            </TableCell>
-                            <TableCell className='text-popover-foreground px-3 py-3 text-xs md:px-4 md:py-3.5 md:text-sm lg:px-6 lg:py-4 lg:text-base'>
-                              <TruncatedTableText text={assignment.bookNameEng} />
-                            </TableCell>
-                            <TableCell className='text-popover-foreground px-3 py-3 text-xs whitespace-nowrap md:px-4 md:py-3.5 md:text-sm lg:px-6 lg:py-4 lg:text-base'>
-                              {assignment.chapterNumber}
-                            </TableCell>
-                            <TableCell className='text-popover-foreground px-3 py-3 text-xs md:px-4 md:py-3.5 md:text-sm lg:px-6 lg:py-4 lg:text-base'>
-                              <TruncatedTableText
-                                text={assignment.assignedUser?.displayName ?? ''}
-                              />
-                            </TableCell>
-                            <TableCell className='text-popover-foreground px-3 py-3 text-xs md:px-4 md:py-3.5 md:text-sm lg:px-6 lg:py-4 lg:text-base'>
-                              <TruncatedTableText
-                                text={assignment.peerChecker?.displayName ?? ''}
-                              />
-                            </TableCell>
-                            <TableCell className='text-popover-foreground px-3 py-3 text-xs whitespace-nowrap md:px-4 md:py-3.5 md:text-sm lg:px-6 lg:py-4 lg:text-base'>
-                              <TruncatedTableText
-                                text={getStatusDisplay(
-                                  assignment.status as ChapterAssignmentStatusType
-                                )}
-                              />
-                            </TableCell>
-                            <TableCell className='text-popover-foreground px-3 py-3 text-xs md:px-4 md:py-3.5 md:text-sm lg:px-6 lg:py-4 lg:text-base'>
-                              <TruncatedTableText
-                                text={formatProgress(
-                                  assignment.completedVerses,
-                                  assignment.totalVerses
-                                )}
-                              />
-                            </TableCell>
-                          </TableRow>
-                        );
-                      })}
-                    </TableBody>
-                  </Table>
-                </div>
-              </TooltipProvider>
-            )}
-          </div>
+          <ChapterAssignmentsTable
+            assignments={filteredAssignments}
+            isLoading={assignmentsLoading}
+            isManager={isManager}
+            isRowActionsDisabled={isLoadingData}
+            selectedAssignments={selectedAssignments}
+            selectedBook={selectedBook}
+            onCheckboxChange={handleCheckboxChange}
+            onRowClick={handleChapterRowClick}
+          />
         </div>
       </div>
 

--- a/src/features/projects/components/TruncatedText.tsx
+++ b/src/features/projects/components/TruncatedText.tsx
@@ -1,0 +1,59 @@
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { useTruncation } from '@/features/projects/hooks/useTruncation';
+
+export const TruncatedTableText = ({ text }: { text: string }): React.JSX.Element => {
+  const { ref, isTruncated } = useTruncation<HTMLDivElement>(text);
+
+  const content = (
+    <div ref={ref} className='max-w-full cursor-default truncate' title=''>
+      {text}
+    </div>
+  );
+
+  if (!isTruncated) return content;
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>{content}</TooltipTrigger>
+        <TooltipContent
+          align='center'
+          className='bg-popover text-popover-foreground border-border rounded-md border px-4 py-2.5 text-sm font-semibold whitespace-nowrap shadow-lg'
+          side='top'
+        >
+          {text}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};
+
+export const TruncatedCardText = ({ text }: { text: string }): React.JSX.Element => {
+  const { ref, isTruncated } = useTruncation<HTMLDivElement>(text);
+
+  const content = (
+    <div
+      ref={ref}
+      className='max-w-full cursor-default truncate text-base font-medium text-gray-600 dark:text-gray-400'
+    >
+      {text}
+    </div>
+  );
+
+  if (!isTruncated) return content;
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>{content}</TooltipTrigger>
+        <TooltipContent
+          align='center'
+          className='bg-popover text-popover-foreground border-border max-w-[350px] rounded-md border px-4 py-2.5 text-sm font-semibold break-all shadow-lg'
+          side='bottom'
+        >
+          {text}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};

--- a/src/features/projects/hooks/useTruncation.ts
+++ b/src/features/projects/hooks/useTruncation.ts
@@ -1,0 +1,35 @@
+import { useLayoutEffect, useRef, useState } from 'react';
+
+interface UseTruncationResult<T extends HTMLElement> {
+  ref: React.RefObject<T>;
+  isTruncated: boolean;
+}
+
+export function useTruncation<T extends HTMLElement = HTMLDivElement>(
+  text: string
+): UseTruncationResult<T> {
+  const ref = useRef<T>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useLayoutEffect(() => {
+    const checkTruncation = (): void => {
+      if (ref.current) {
+        setIsTruncated(ref.current.scrollWidth > ref.current.clientWidth);
+      }
+    };
+
+    checkTruncation();
+    let timeoutId: NodeJS.Timeout;
+    const debouncedCheck = (): void => {
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(checkTruncation, 150);
+    };
+    window.addEventListener('resize', debouncedCheck);
+    return () => {
+      clearTimeout(timeoutId);
+      window.removeEventListener('resize', debouncedCheck);
+    };
+  }, [text]);
+
+  return { ref, isTruncated };
+}


### PR DESCRIPTION
Things done in this PR:- 

1. Created a separate component for chapterAssignmentsTable
2.  Functional Requirements

 Layout Breakpoint
- [x]  Below a 1024px viewport width, the two-column layout switches to a single stacked column.
- [x]  At 1024px and above, the layout remains unchanged (metadata/users panel beside the chapter table).

 Stacked Layout (below 1024px)


- [x] The metadata card and Project Users section render side by side above the chapter table: metadata card on the left, Project Users table on the right.
- [x]  The chapter table toolbar (book filter and Assign button) and the chapter table itself render below, full width.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a chapter assignments table with loading/empty/populated states and sticky header.
  * Introduced reusable truncated text rendering with tooltips for full visibility.
* **Bug Fixes**
  * Improved responsive alignment and height coordination on the project details page.
* **UI Improvements**
  * Refreshed the project users panel layout, spacing, and error banner presentation.
  * Improved assignment row interactions (click + optional checkbox) and progress display formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->