### PR TITLE
fix(resources): keep Translation Questions collapsed on tab load

### DIFF
--- a/src/features/resources/components/ResourcePanel.tsx
+++ b/src/features/resources/components/ResourcePanel.tsx
@@ -246,6 +246,11 @@ export const ResourcePanel: React.FC<ResourcePanelProps> = ({
 
   useEffect(() => {
     if (localizeRefName.length > 0 && shouldFetchResources) {
+      if (selectedResource.id === 'UWTranslationQuestions') {
+        setOpenItem(prev => (prev.length === 0 ? prev : []));
+        return;
+      }
+
       const firstItemId = localizeRefName[0].id.toString();
       setOpenItem(prev => {
         if (prev.length === 1 && prev[0] === firstItemId) return prev;
@@ -256,7 +261,7 @@ export const ResourcePanel: React.FC<ResourcePanelProps> = ({
       setOpenItem(prev => (prev.length === 0 ? prev : []));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [localizeRefName, shouldFetchResources]);
+  }, [localizeRefName, shouldFetchResources, selectedResource.id]);
 
   useEffect(() => {
     if (


### PR DESCRIPTION
Previously the first TQ item auto-expanded like other resource tabs, showing the answer before the translator considered the question. Now TQ starts fully collapsed while still prefetching guide content in the background, so expanding a question is instant. Other tabs' auto-expand behavior is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the translation questions resource to remain collapsed when opened, preventing unintended guide and audio loading.
  * Ensured accordion initialization refreshes correctly when switching between resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->