### PR TITLE
docs: land Lynx client-USFM + RTE PoC design docs

### DIFF
--- a/docs/proposals/lynx-client-usfm-poc/design.md
+++ b/docs/proposals/lynx-client-usfm-poc/design.md
@@ -1,0 +1,116 @@
+# Lynx Client-Side USFM PoC — Design
+
+**Status:** PoC (exploratory, not for production merge as-is).
+**Code:** stays on the reference branch `poc/lynx-client-usfm` ([PR #327](https://github.com/eten-tech-foundation/fluent-web/pull/327)); only this design doc lands on `main`.
+**Date:** 2026-07-01.
+
+## 1. Background
+
+Fluent stores translations as **per-verse plain text** and only ever materializes USFM **server-side**: fluent-api parses uploaded USFM with `usfm-grammar` (`src/lib/usfm-converter.ts`) and assembles USFM on export (`generateUSFMText`, streamed as a ZIP consumed by `useExportUsfm.ts`). The web app has **no scripture document model** — the drafting editor is a plain `<textarea>` per verse (`DraftingPage.tsx`).
+
+[Lynx](https://github.com/sillsdev/lynx) (SIL, MIT) is a TypeScript library for adding **diagnostics, quick fixes, and on-type formatting** to translation editors, modeled on LSP. The February 10, 2026 discovery session (Damien Daspit, Benjamin King, JoEllen Magnus / Joel Mathew, Kasey W) established:
+
+- Lynx runs **entirely in the browser** (proven in Scripture Forge) — published npm packages: `@sillsdev/lynx` (core), `@sillsdev/lynx-usfm`, `@sillsdev/lynx-punctuation-checker`, `@sillsdev/lynx-delta`.
+- Checkers operate on a format-agnostic **`ScriptureDocument`** typed node tree (books/chapters/verses/paragraphs/notes/…); USFM, Delta (and potentially USJ/USX) are interchangeable backends.
+- Greek Room–style server checks fit as **`DiagnosticProvider`s that call a backend**, with the provider controlling debounce/batching.
+- JoEllen's "easy win" framing: integrate the Lynx interface with the existing punctuation checker first; Greek Room provider later.
+- Kasey's idea: run Lynx as a **linter over USFM exports**.
+
+Meanwhile, the merged-on-main **Repeated Word Check UI proposal** (`docs/proposals/repeated-word-check/`, PR #305) designs a Checks tab + per-check accordion panel with Ignore Here/Everywhere suppression — explicitly anticipating more checks (Wildebeest, spell check). Each new check currently implies bespoke plumbing (hook, identity keys, suppression cascade). Lynx's `DiagnosticProvider` / `Diagnostic.fingerprint` / `DiagnosticDismissalStore` are the general form of exactly those parts.
+
+## 2. Goal
+
+Prove, inside fluent-web's real stack (Vite 8, React 18, TS 6, TanStack Router, Tailwind 4 + shadcn), that:
+
+1. `@sillsdev/lynx-usfm` can parse USFM into a **typed `ScriptureDocument` in the browser** — no server round-trip.
+2. The front end can **understand verse structure natively**: walk the node tree, render chapters/verses/paragraphs, map any text range to a verse reference.
+3. One **canonical client-side USFM representation** can be derived from Fluent's per-verse data (same assembly the export endpoint uses) and shared across checks and formatting.
+4. Real Lynx checks run live on it: the four `StandardRuleSets.English` punctuation/quotation/character providers plus a custom provider (vendored verse-order example — the template for a future Greek Room provider), with **diagnostics, quick fixes, dismissal, and on-type smart quotes**.
+
+### Non-goals
+
+- No changes to `DraftingPage` or any production flow; the PoC is one isolated authenticated route.
+- No editor decision (Quill/Lexical/CodeMirror is a separate track); a `<textarea>` + overlay is enough to prove the engine.
+- No Greek Room calls; the vendored provider demonstrates the provider contract only.
+- No persistence of dismissals (in-memory; the write-up maps it to `user_settings`/editor-state).
+
+## 3. Approaches considered
+
+- **A. Standalone sandbox app.** Fast, zero risk — but proves nothing about fluent-web's bundler/TS/i18n reality, and lands no reusable code. Rejected.
+- **B. Isolated PoC route inside fluent-web (chosen).** Proves the actual integration surface (Vite dep handling, engine-strict, conventions), can pull real chapter data through existing endpoints, and is demoable/PR-able to the team.
+- **C. Wire Lynx into the drafting textarea now.** Most "real," but pre-empts the open editor/document-model decision and turns a PoC into a product change. Rejected for now; the PoC's verse-mapping section is designed to show how C would work later.
+
+## 4. Architecture
+
+```
+src/features/lynx/
+  assets/usfm.sty                  # vendored Paratext stylesheet (see §6.1)
+  lib/
+    stylesheet.ts                  # browser-safe UsfmStylesheet construction
+    usfm-assembly.ts               # verses -> USFM (mirror of fluent-api generateUSFMText)
+    workspace.ts                   # createLynxWorkspace(): Localizer + factories + providers
+    verse-order-provider.ts        # vendored @sillsdev/lynx-examples provider (provenance header)
+    locales/…                      # vendored en/es JSON for the provider namespace
+    verse-map.ts                   # ScriptureDocument walk: structure snapshot + range->verse ref
+    sample-usfm.ts                 # demo USFM with seeded issues
+  hooks/
+    useLynxDocument.ts             # document lifecycle + diagnostics subscription + edits
+  components/
+    LynxUsfmPocPage.tsx            # page shell, source switcher (sample | chapter API)
+    UsfmEditor.tsx                 # textarea + diagnostic highlight overlay + on-type quotes
+    ChecksPanel.tsx                # per-check accordion, verse-grouped, fixes/dismiss
+    StructurePanel.tsx             # typed node tree + formatted scripture preview
+src/routes/_authenticated/lynx-usfm.tsx   # thin route file (TanStack file-based)
+```
+
+**One Workspace per page mount.** `useLynxDocument` owns a single `Workspace<TextEdit>` + `DocumentManager<UsfmDocument>` created once (ref), `fireOpened` on mount / source change, `fireChanged` with **full-content replace** on each edit (Lynx re-parses incrementally line-wise internally; per-keystroke incremental ranges are an optimization the PoC doesn't need), `fireClosed` on unmount.
+
+**Data flow (edit cycle):**
+
+1. `UsfmEditor` onChange → hook state → `documentManager.fireChanged(uri, { contentChanges: [{ text }], version: n+1 })`.
+2. Providers emit on `workspace.diagnosticsChanged$` (push, RxJS) → hook merges per-source → React state.
+3. `verse-map.ts` re-walks `document.findNodes(...)` → structure snapshot (chapters, verses, ranges) → panels re-render; each diagnostic gets a verse ref by range containment.
+4. Quick fix click → `workspace.getDiagnosticFixes(uri, d)` → apply returned `TextEdit[]` to the string (via `document.offsetAt`) → back to step 1.
+5. Dismiss click → app-side suppression keyed by a locally computed fingerprint. (The *published* core 0.3.5 has no dismissal/fingerprint support yet — that is exactly the in-progress work Damien described in the February meeting, present on repo HEAD as `dismissDiagnostic` + `DiagnosticDismissalStore`. Emulating it client-side also mirrors how the Repeated-Word proposal filters findings.)
+6. Typing a trigger char (from `getOnTypeTriggerCharacters()`) → `workspace.getOnTypeEdits(uri, pos, ch)` → apply (smart-quote autocorrect).
+
+**Published-API note.** npm 0.3.5 differs from repo HEAD (and HEAD's README): providers implement `getDiagnosticFixes` returning `DiagnosticFix { title, isPreferred?, edits }` — there are no command actions, no `fingerprint` field, no dismissal store. The vendored verse-order provider is adapted accordingly (its "exclude verse" command action was dropped).
+
+**Source modes:** (a) **Sample** — bundled USFM with seeded issues (default; works with no data dependencies); (b) **From chapter** — fetch source verses via the same endpoint the drafting loader uses (`GET /bibles/:bibleId/books/:bookId/chapters/:n/texts`), assemble USFM client-side with `usfm-assembly.ts`, then parse/check. Mode (b) is the "one canonical representation from real Fluent data" + "lint the export client-side" demonstration.
+
+## 5. Browser hazards — all three predicted, all three confirmed live, all worked around
+
+`@sillsdev/lynx-usfm` had apparently never been exercised in a browser (the VS Code extension is Node; Scripture Forge uses the Delta factory, not USFM). Status after live verification on 2026-07-01 — each is a ready-made upstream contribution for the collaboration Damien invited:
+
+1. **CONFIRMED — `UsfmStylesheet` construction is file-based.** The public constructor reads from disk (`fs.readFileSync`); `parseTagEntries(content)` exists but is `private` in the types. Workaround (`lib/stylesheet.ts`): vendor `usfm.sty` (87 KB, from `@sillsdev/machine/dist/corpora/`, MIT; also not reachable through the package's `exports` map) as a `?raw` Vite asset and call `parseTagEntries` through a narrow, commented cast. Upstream ask: a content-based constructor/factory on `UsfmStylesheet`.
+2. **CONFIRMED — `@sillsdev/machine` corpora crashes on import in the browser.** `usfm-stylesheet.mjs` computes `dirname(fileURLToPath(import.meta.url))` at module scope; the package's own `browser` field maps `fs`/`path`/`url` to empty modules, so the page died with `TypeError: fileURLToPath is not a function`. Workaround (`vite.config.ts` + `lib/node-shims.ts`): exact-match regex aliases (`/^(?:node:)?url$/` etc. — string keys are prefix-matched by Vite 8/rolldown and mangled `fs/promises` into a path under the shim) pointing the four ids at inert implementations; disabled under vitest, where real Node modules must remain. Upstream ask: guard the module-scope calls so the `browser` field alone suffices.
+3. **CONFIRMED — checker locale JSONs don't survive dep optimization.** `createLocaleLoader`'s template-literal dynamic `import()` can't be rewritten by the optimizer; diagnostics rendered as raw i18next keys (`diagnosticMessagesByCode.…`). Workaround (`lib/workspace.ts`): `Localizer.addNamespace` is first-write-wins, so the five checker namespaces (`quotation`, `allowedCharacters`, `pairedPunctuation`, `punctuation-context`, `standardPunctuationFixes`) are pre-registered with statically imported, vendored `en.json` resources before `workspace.init()`. Upstream ask: bundler-friendly locale shipping (static import map or explicit exports).
+
+Bundle: the whole feature (lynx core + usfm + punctuation-checker + machine corpora + rxjs + a second i18next instance + the raw `usfm.sty`) lands as one lazily loaded route chunk — **~326 KB, 75 KB gzip** — thanks to the router's `autoCodeSplitting`; the main bundle is untouched. Core pins i18next ^23 while the app uses ^26; the `Localizer` creates its own instance, so they coexist.
+
+### Live findings beyond the hazards
+
+- **Performance:** parse + all five checkers on the sample ≈ 3 ms; Genesis 1 (31 verses, Gujarati IRV, fetched from the local fluent-api and assembled client-side) ≈ 28 ms. Interactive-keystroke budget is comfortable without any debouncing.
+- **Rule sets are language-specific:** running `StandardRuleSets.English` over Gujarati text produced ~2,600 allowed-character warnings. Not a bug — the character whitelist and quote conventions are `RuleSet` builder configuration, and a real integration must derive them from the project's target language. This is a first-class agenda item for the SIL collaboration (what does a Gujarati/Hindi rule set look like?).
+- **Quotation analysis is document-wide** (a quote-stack), so an unclosed quote early in a chapter shifts where later imbalances are reported. Fine for documents; worth thinking about for verse-scoped UX.
+
+## 6. UI
+
+Two-column layout under the standard authenticated header, all shadcn components already in the repo (Card, Badge, Button, Select, Accordion, Tooltip, Separator):
+
+- **Left: USFM editor** — monospace textarea with an aligned overlay rendering wavy underlines/tints per diagnostic severity; issue count chips; on-type smart quotes live.
+- **Right, tab 1 "Checks"** — deliberately echoes the Repeated Word Check panel proposal: one accordion section per provider (Quotation, Allowed Characters, Paired Punctuation, Punctuation Context, Verse Order), findings **grouped by verse** with context snippets, severity badges, `[Fix: …]` buttons for actions with edits, `[Dismiss]` for fingerprinted diagnostics, zero state "No issues found".
+- **Right, tab 2 "Structure"** — the typed node tree (type, range, preview) + a **formatted scripture preview** (chapter numbers, superscript verse numbers, paragraphs) rendered *purely from the parsed model* — the "front end understands verse structure natively" money shot.
+- Source switcher (Sample / From chapter with bible/book/chapter inputs) in the page header.
+
+## 7. Verification
+
+- **Vitest (jsdom)**: stylesheet builds in a browser-like env with no `fs`; sample USFM parses to expected book/chapter/verse counts; seeded issues produce expected diagnostics per source; missing-verse quick fix round-trips (apply edit → diagnostic disappears); verses→USFM assembly matches the server's shape.
+- **Live**: run the app against the local stack, drive the page (both source modes), screenshot; confirm no server round-trips during checking (network tab quiet after load).
+
+## 8. Follow-on roadmap this PoC informs (detail in `lynx-fluent-assessment.md`)
+
+1. Checks panel engine: back the proposed Checks tab with a `Workspace` instead of per-check bespoke hooks; `fingerprint` ↔ occurrence identity, `DiagnosticDismissalStore` ↔ editor-state/user_settings suppression cascade.
+2. Greek Room / Wildebeest / spell check as `DiagnosticProvider`s calling the existing fluent-ai proxy.
+3. Export linting: run `getDiagnostics` over assembled USFM before download (client) and/or in fluent-api tests.
+4. Editor track: when Fluent picks a rich editor, keep the Lynx document as the shared model (Scripture Forge precedent: Quill + lynx-delta).

--- a/docs/proposals/lynx-client-usfm-poc/design.md
+++ b/docs/proposals/lynx-client-usfm-poc/design.md
@@ -69,9 +69,9 @@ src/routes/_authenticated/lynx-usfm.tsx   # thin route file (TanStack file-based
 
 1. `UsfmEditor` onChange → hook state → `documentManager.fireChanged(uri, { contentChanges: [{ text }], version: n+1 })`.
 2. Providers emit on `workspace.diagnosticsChanged$` (push, RxJS) → hook merges per-source → React state.
-3. `verse-map.ts` re-walks `document.findNodes(...)` → structure snapshot (chapters, verses, ranges) → panels re-render; each diagnostic gets a verse ref by range containment.
-4. Quick fix click → `workspace.getDiagnosticFixes(uri, d)` → apply returned `TextEdit[]` to the string (via `document.offsetAt`) → back to step 1.
-5. Dismiss click → app-side suppression keyed by a locally computed fingerprint. (The *published* core 0.3.5 has no dismissal/fingerprint support yet — that is exactly the in-progress work Damien described in the February meeting, present on repo HEAD as `dismissDiagnostic` + `DiagnosticDismissalStore`. Emulating it client-side also mirrors how the Repeated-Word proposal filters findings.)
+3. `verse-map.ts` re-walks `document.findNodes(...)` → structure snapshot (chapters, verses, ranges) → panels re-render; `verseRefAtRange` resolves each diagnostic to the last verse starting at or before it. It returns `undefined` for anything outside a verse (`\id`/`\h`/`\mt` header lines): those findings still render, just without a verse chip. Findings are listed per provider, not bucketed by verse, so an unscoped diagnostic is never dropped.
+4. Quick fix click → `workspace.getDiagnosticFixes(uri, d)` → `DiagnosticFix[]`; the clicked fix's `fix.edits` are applied to the string (via `document.offsetAt`) → back to step 1. The PoC's fixes carry a single edit; applying a multi-edit fix safely (one snapshot, overlap check, descending offsets) is left to the production implementation.
+5. Dismiss click → app-side suppression keyed by `source|code|anchor|occurrence`, where `anchor` is the diagnostic's `verseRef` when one resolved and its `line:character` otherwise. The verse-anchored form survives re-parsing; **the positional fallback does not** — editing earlier text shifts the anchor and the dismissal is lost. Occurrence identity is the ordinal within `source|code|anchor` in document order. (The *published* core 0.3.5 has no dismissal/fingerprint support yet — that is exactly the in-progress work Damien described in the February meeting, present on repo HEAD as `dismissDiagnostic` + `DiagnosticDismissalStore`. Emulating it client-side also mirrors how the Repeated-Word proposal filters findings.)
 6. Typing a trigger char (from `getOnTypeTriggerCharacters()`) → `workspace.getOnTypeEdits(uri, pos, ch)` → apply (smart-quote autocorrect).
 
 **Published-API note.** npm 0.3.5 differs from repo HEAD (and HEAD's README): providers implement `getDiagnosticFixes` returning `DiagnosticFix { title, isPreferred?, edits }` — there are no command actions, no `fingerprint` field, no dismissal store. The vendored verse-order provider is adapted accordingly (its "exclude verse" command action was dropped).
@@ -90,7 +90,7 @@ Bundle: the whole feature (lynx core + usfm + punctuation-checker + machine corp
 
 ### Live findings beyond the hazards
 
-- **Performance:** parse + all five checkers on the sample ≈ 3 ms; Genesis 1 (31 verses, Gujarati IRV, fetched from the local fluent-api and assembled client-side) ≈ 28 ms. Interactive-keystroke budget is comfortable without any debouncing.
+- **Performance:** parse + all five checkers on the sample ≈ 3 ms; Genesis 1 (31 verses, Gujarati IRV, fetched from the local fluent-api and assembled client-side) ≈ 28 ms. Caveats before this number is used as a budget: single machine, single browser (Chromium), wall-clock of a handful of runs rather than p95/p99, and the pass runs **on the main thread**, so 28 ms overruns a 60 Hz frame (16.7 ms). The PoC needs no debouncing to feel immediate at chapter size, but a production integration editing longer documents should measure percentiles and plan for debouncing or a worker rather than assume headroom.
 - **Rule sets are language-specific:** running `StandardRuleSets.English` over Gujarati text produced ~2,600 allowed-character warnings. Not a bug — the character whitelist and quote conventions are `RuleSet` builder configuration, and a real integration must derive them from the project's target language. This is a first-class agenda item for the SIL collaboration (what does a Gujarati/Hindi rule set look like?).
 - **Quotation analysis is document-wide** (a quote-stack), so an unclosed quote early in a chapter shifts where later imbalances are reported. Fine for documents; worth thinking about for verse-scoped UX.
 
@@ -99,16 +99,26 @@ Bundle: the whole feature (lynx core + usfm + punctuation-checker + machine corp
 Two-column layout under the standard authenticated header, all shadcn components already in the repo (Card, Badge, Button, Select, Accordion, Tooltip, Separator):
 
 - **Left: USFM editor** — monospace textarea with an aligned overlay rendering wavy underlines/tints per diagnostic severity; issue count chips; on-type smart quotes live.
-- **Right, tab 1 "Checks"** — deliberately echoes the Repeated Word Check panel proposal: one accordion section per provider (Quotation, Allowed Characters, Paired Punctuation, Punctuation Context, Verse Order), findings **grouped by verse** with context snippets, severity badges, `[Fix: …]` buttons for actions with edits, `[Dismiss]` for fingerprinted diagnostics, zero state "No issues found".
+- **Right, tab 1 "Checks"** — deliberately echoes the Repeated Word Check panel proposal: one accordion section per provider (Quotation, Allowed Characters, Paired Punctuation, Punctuation Context, Verse Order), each finding **labelled with its verse** (chip omitted when the range sits outside any verse) plus context snippets, severity badges, `[Fix: …]` buttons for actions with edits, `[Dismiss]` for fingerprinted diagnostics, zero state "No issues found".
 - **Right, tab 2 "Structure"** — the typed node tree (type, range, preview) + a **formatted scripture preview** (chapter numbers, superscript verse numbers, paragraphs) rendered *purely from the parsed model* — the "front end understands verse structure natively" money shot.
 - Source switcher (Sample / From chapter with bible/book/chapter inputs) in the page header.
 
 ## 7. Verification
 
-- **Vitest (jsdom)**: stylesheet builds in a browser-like env with no `fs`; sample USFM parses to expected book/chapter/verse counts; seeded issues produce expected diagnostics per source; missing-verse quick fix round-trips (apply edit → diagnostic disappears); verses→USFM assembly matches the server's shape.
+- **Vitest (jsdom)**: stylesheet builds in a browser-like env with no `fs`; sample USFM parses to expected book/chapter/verse counts; seeded issues produce expected diagnostics per source; missing-verse quick fix round-trips (apply edit → diagnostic disappears); verses→USFM assembly produces the marker structure the server's exporter emits. That last test asserts **structure, not byte equality** with `generateUSFMText` — enough to show the client can assemble checkable USFM, not enough to claim the two are interchangeable. Establishing canonical equivalence (exact output or a normalized golden fixture, over chapters with missing verses, empty text and markers outside the curated subset) is a prerequisite for ever round-tripping client-assembled USFM back into storage.
 - **Live**: run the app against the local stack, drive the page (both source modes), screenshot; confirm no server round-trips during checking (network tab quiet after load).
 
-## 8. Follow-on roadmap this PoC informs (detail in `lynx-fluent-assessment.md`)
+## 8. What the PoC deliberately leaves open
+
+Scope boundaries, recorded so a production integration starts from the real state rather than from this page's happy path.
+
+- **Diagnostic lifecycle.** The hook renders whatever the last `diagnosticsChanged$` emission carried, per source. It does not correlate results with the document `version` that produced them, so a slow provider answering after a newer edit can briefly paint stale ranges; it does not clear findings while a re-check is in flight; and a provider that throws simply emits nothing, which the panel renders as the "No issues found" zero state. A real Checks panel needs version-tagged results, an explicit in-flight state, and an error state distinct from "clean" — otherwise a broken check looks like a passing one, which is the dangerous failure here.
+- **Unscoped diagnostics.** Findings outside any verse render without a verse chip (see §4). Nothing groups them under a structural heading, and quotation analysis is document-wide, so an early unclosed quote can report against a later verse than the one a user would blame.
+- **Multi-edit fixes.** Only single-edit fixes were exercised.
+- **Canonical USFM.** Assembly is verified structurally, not byte-for-byte (see §7).
+- **Rule sets are language-specific.** `StandardRuleSets.English` over Gujarati produced ~2,600 false warnings; a real integration must derive the rule set from the project's target language.
+
+## 9. Follow-on roadmap this PoC informs (detail in `lynx-fluent-assessment.md`)
 
 1. Checks panel engine: back the proposed Checks tab with a `Workspace` instead of per-check bespoke hooks; `fingerprint` ↔ occurrence identity, `DiagnosticDismissalStore` ↔ editor-state/user_settings suppression cascade.
 2. Greek Room / Wildebeest / spell check as `DiagnosticProvider`s calling the existing fluent-ai proxy.

--- a/docs/proposals/lynx-client-usfm-poc/lynx-fluent-assessment.md
+++ b/docs/proposals/lynx-client-usfm-poc/lynx-fluent-assessment.md
@@ -18,10 +18,12 @@ Fluent's first check is now designed: the Repeated Word Check UI proposal builds
 | `useRepeatedWordsCheck` hook per check | `DiagnosticProvider` per check behind one `Workspace` |
 | Findings envelope from the fluent-ai proxy | `Diagnostic { source, range, severity, message, data }` |
 | `snt_id` + word + ordinal occurrence identity | `Diagnostic.fingerprint` (landing on Lynx HEAD) |
-| Ignore Here / Everywhere cascade in editor-state / `user_settings` | `DiagnosticDismissalStore` interface (Lynx HEAD) — Fluent implements it over those same stores |
-| "Show Ignored" + Undo | dismissal filtering built into `Workspace` |
+| Ignore Here / Everywhere cascade in editor-state / `user_settings` | `DiagnosticDismissalStore` interface (**Lynx HEAD only**) — Fluent implements it over those same stores |
+| "Show Ignored" + Undo | dismissal filtering built into `Workspace` (**Lynx HEAD only**) |
 | deferred "Drop duplicate" one-click fix | `DiagnosticFix` (edits) — the machinery already exists |
 | chapter re-check on every auto-save | `DocumentManager.fireChanged` + push-based `diagnosticsChanged$` |
+
+Rows marked **Lynx HEAD only** do not exist in the published 0.3.5 the PoC pins, so the PoC contracts dismissal and occurrence keying app-side instead (`source|code|anchor|occurrence` — see the design doc §4). Everything else in the table is available on 0.3.5 today.
 
 None of this forces a rewrite of the in-flight Repeated Word work. The realistic sequence is: land #277/#278 as designed, and when check **#2** arrives, put the panel on a `Workspace` so the third, fourth, fifth check are providers, not projects.
 

--- a/docs/proposals/lynx-client-usfm-poc/lynx-fluent-assessment.md
+++ b/docs/proposals/lynx-client-usfm-poc/lynx-fluent-assessment.md
@@ -1,0 +1,71 @@
+# What Lynx Can Do for Fluent
+
+**Companion to:** [`design.md`](design.md) · the running demo at `/lynx-usfm` (authenticated route) on the reference branch `poc/lynx-client-usfm` ([PR #327](https://github.com/eten-tech-foundation/fluent-web/pull/327)).
+**Grounding:** the 2026-02-10 Lynx|Fluent technical discovery session (Damien Daspit, Benjamin King, JoEllen Magnus / Joel Mathew, Kasey W), the Repeated Word Check UI proposal (`docs/proposals/repeated-word-check/`, PR #305), and what this PoC empirically proved.
+
+## 1. What Lynx is
+
+[Lynx](https://github.com/sillsdev/lynx) (SIL, MIT, published on npm) is a TypeScript library for adding quality checking and formatting assistance to scripture editing environments, deliberately modeled on the Language Server Protocol: **diagnostic providers** report issues with ranges and severities, offer **quick fixes** (text edits), and **on-type formatting providers** correct text as the user types. A **workspace** orchestrates any number of providers behind one API; a **document manager** feeds them a format-agnostic, typed **`ScriptureDocument`** node tree (books/chapters/verses/paragraphs/notes/…) with USFM and Quill-Delta backends today. It runs entirely in the browser (Scripture Forge is the production proof; this PoC is the Fluent-stack proof) and is equally happy in Node (SIL's VS Code extension, future Paratext extension).
+
+## 2. Why this fits Fluent specifically
+
+In the February meeting Joel framed the need precisely: Fluent wants an increasing list of checks (Greek Room first) **without a bespoke integration per tool** — "a standard interface where different checking tools can be integrated into… and we don't have to change the UI side drastically."
+
+Fluent's first check is now designed: the Repeated Word Check UI proposal builds a Checks tab + per-check accordion panel with Ignore Here/Everywhere suppression, refreshed on auto-save, explicitly anticipating sibling checks (Wildebeest, spell check). Every concept in that proposal has a general Lynx counterpart:
+
+| Repeated Word Check proposal (bespoke) | Lynx (general) |
+| --- | --- |
+| `useRepeatedWordsCheck` hook per check | `DiagnosticProvider` per check behind one `Workspace` |
+| Findings envelope from the fluent-ai proxy | `Diagnostic { source, range, severity, message, data }` |
+| `snt_id` + word + ordinal occurrence identity | `Diagnostic.fingerprint` (landing on Lynx HEAD) |
+| Ignore Here / Everywhere cascade in editor-state / `user_settings` | `DiagnosticDismissalStore` interface (Lynx HEAD) — Fluent implements it over those same stores |
+| "Show Ignored" + Undo | dismissal filtering built into `Workspace` |
+| deferred "Drop duplicate" one-click fix | `DiagnosticFix` (edits) — the machinery already exists |
+| chapter re-check on every auto-save | `DocumentManager.fireChanged` + push-based `diagnosticsChanged$` |
+
+None of this forces a rewrite of the in-flight Repeated Word work. The realistic sequence is: land #277/#278 as designed, and when check **#2** arrives, put the panel on a `Workspace` so the third, fourth, fifth check are providers, not projects.
+
+**The second thing Lynx buys is the document model itself.** Fluent stores per-verse plain text; USFM exists only server-side (usfm-grammar import, string-concatenation export). Joel: "we are already hitting the need for having more formatted scripture content on the screen… that entails deciding what is the data model." Lynx's `ScriptureDocument` is that model, shared with Scripture Forge and Paratext lineage — and the PoC shows the front end deriving it on the fly from the verses Fluent already has, so adopting it requires **no storage change**.
+
+## 3. What the PoC proves
+
+Run it from the reference branch: `/lynx-usfm` (any authenticated user; sample loads automatically, "Assemble chapter → USFM" pulls live data).
+
+1. **USFM parses to a typed document in the browser** — chapters, verses, paragraphs walked from the node tree, rendered as a formatted scripture preview and a node inspector; ~3 ms for the sample, ~28 ms for a real 31-verse chapter. No server round-trips after load.
+2. **Real checks run live**: the four `StandardRuleSets.English` providers (quotation pairing, allowed characters, paired punctuation, punctuation context) plus a vendored verse-order provider (the template for Fluent-authored providers). Diagnostics carry ranges → inline underlines in the editor and **verse references** (via the node tree) → verse-grouped rows in a Checks-panel-shaped UI with fix/ignore/undo.
+3. **Quick fixes and on-type formatting work end-to-end**: "Insert missing verse" splices a correct `\v 4` edit; typing `"` autocorrects to the context-correct curly quote at the caret.
+4. **One canonical representation**: the PoC assembles USFM from verses with the *same logic as the server export* (`generateUSFMText` mirrored), fetched from the same bible-texts endpoint the drafting page uses — Kasey's "lint the export" idea, running before anything leaves the browser. The same module works in fluent-api tests.
+5. **It fits the stack**: Vite 8 + React 18 + TS 6 + TanStack Router; the whole feature is one lazy route chunk (75 KB gzip); 14 vitest specs cover the non-UI modules.
+6. **Three packaging hazards found and worked around** (browser-first consumer feedback SIL doesn't have yet — see design.md §5): file-based `UsfmStylesheet` construction, module-scope Node calls in `@sillsdev/machine`, and bundler-hostile locale loading in the checker package.
+7. **Rule sets must be per-language**: English rules over Gujarati text → ~2,600 allowed-character warnings. The configs are builder-based (`QuotationConfig`, `CharacterRegexWhitelist`…); deriving them from the project's target language is a real integration workstream — and a concrete collaboration topic with SIL.
+
+## 4. Where Lynx helps, ranked
+
+1. **Checks panel engine (the "easy win" JoEllen asked about).** Back the proposed Checks tab with a `Workspace`; punctuation/quotation/character checks come free and run offline-fast; the panel stops being per-check plumbing. Effort: the PoC's `useLynxDocument` hook is most of the shape.
+2. **Greek Room / Wildebeest / spell check as providers.** Exactly the pattern discussed in February: a `DiagnosticProvider` that debounces, calls the existing fluent-api → fluent-ai proxy, and maps findings to `Diagnostic`s (range from verse + offsets). The provider owns batching/caching policy — and Joel's caching idea is a shareable utility SIL wants too.
+3. **Per-language rule sets.** Small, high-leverage: a rule-set factory keyed by target language (quote conventions, character sets, punctuation) — likely the first thing Fluent contributes upstream that other Lynx consumers reuse.
+4. **Export linting.** Run `getDiagnostics` over assembled USFM client-side before download and as a fluent-api test over export output (Kasey's use case; the PoC's assembly module is isomorphic).
+5. **The editor/document-model decision.** When Fluent picks a rich editor ("we don't want to make our own editor"), Lynx keeps the checking layer editor-agnostic: Scripture Forge pairs it with Quill via `lynx-delta`; a Fluent editor would bind the same workspace to its change events. Adopting `ScriptureDocument` as the shared representation now (derived, not stored) keeps that door open — including the shared-editor synergy Damien floated.
+6. **Mobile.** The companion app runs the same TypeScript; local checks (punctuation, verse order) work offline, which Kasey flagged as the forcing function for client-side checking.
+
+## 5. What Fluent gives back (the collaboration Damien invited)
+
+- The three packaging fixes (browser-safe stylesheet construction, guarded module-scope Node calls, bundler-friendly locales) — small PRs with an eager first consumer.
+- Browser/bundler CI coverage for lynx-usfm (SIL currently exercises it only in Node).
+- Requirements pressure on the dismissal/fingerprint work in progress (Fluent's Ignore Here/Everywhere cascade is a concrete `DiagnosticDismissalStore` implementation) and on the caching utility.
+- Per-language rule sets, and eventually a Greek Room provider other Lynx hosts (Scripture Forge, Paratext) could adopt — the "bigger collaboration" from the meeting.
+
+## 6. Risks and open questions
+
+- **Pre-1.0 API drift.** Published core is 0.3.5; HEAD already renames `getDiagnosticFixes` → `getDiagnosticActions` and adds dismissal. Pin versions, expect small migrations, and use the collaboration channel (SIL offered repo access + joint review of core changes) to see changes coming.
+- **Localization.** Lynx localizes via its own i18next instance; packages ship `en`/`es`/`npi` today. Fluent needs `hi` (and later others) — contribute locale files upstream or register app-side namespaces (the PoC shows the mechanism).
+- **Verse-scoped UX vs document-scoped checks.** Quotation analysis is a document-wide quote stack; an unclosed quote in verse 5 can surface at verse 12. Verse-grouped display works (the PoC maps ranges → verses), but messaging may need care.
+- **Sustained SIL bandwidth.** JoEllen was explicit that integration time can flex toward Lynx but nothing is formally planned; Bianca's funding thread matters for pace.
+
+## 7. Suggested next steps
+
+1. Demo `/lynx-usfm` at the next Lynx|Fluent sync; walk the three upstream findings with Damien.
+2. File the three packaging issues on sillsdev/lynx + sillsdev/machine (offer the PoC's workarounds as PRs).
+3. Spike a Hindi/Gujarati rule set to size the per-language configuration work.
+4. Decide the engine question for the Checks panel at check #2: adopt `Workspace` + write the Greek Room provider against the existing proxy.
+5. Feed Fluent's suppression-cascade requirements into SIL's in-flight dismissal design (it is being built for pluggable stores *right now* — February transcript).

--- a/docs/proposals/rte-poc/design.md
+++ b/docs/proposals/rte-poc/design.md
@@ -1,0 +1,51 @@
+# RTE PoC — SharedEditor in fluent-web (issue #375)
+
+**Status:** PoC (exploratory; decides the editor library, not production code).
+**Code:** stays on the reference branch `poc/rte-shared-editor` (stacked on `poc/lynx-client-usfm`, [PR #327](https://github.com/eten-tech-foundation/fluent-web/pull/327), to reuse the Lynx machinery); only this design doc lands on `main`.
+**Approved:** 2026-07-17 (design discussed and approved in session; order: SharedEditor first, ProseMirror counterpart after on the same harness).
+
+## Goal
+
+Roadmap step 3 for the Rich Text Editor: a working pericope-view editing PoC inside fluent-web for the primary candidate, demonstrating the five things the R&D spikes could not — real in-app integration, pericope-scoped editing, the on-demand format bar, the USJ save path, and Lynx check highlights — so the team can make the final editor decision against the ProseMirror counterpart.
+
+## Decisions
+
+1. **Editor:** `@eten-tech-foundation/platform-editor` 0.8.x from npm, `Editorial` component (Marginal is deprecated). `EditorRef` provides `setAnnotation`/`removeAnnotation` for check highlights. React ≥18.3.1 peer matches fluent-web; yjs peer not needed on the Editorial path.
+2. **USJ on the client:** a minimal, deterministic USFM→USJ converter covering only the curated V1 subset our assembled USFM contains (`\id \h \mt \c \p \v`). The canonical converter decision is explicitly out of scope (issue #375); this keeps the PoC honest and dependency-free. The reverse — USJ→verse texts — is a small tree walk used by the save path.
+3. **Pericope scoping:** boundaries come from the existing `useChapterPericopes` hook (`{pericopeNumber, pericopeTitle, verses[]}`). The page slices the chapter USJ down to the selected pericope's verses, the editor edits only the slice, and saving merges the slice back into the chapter USJ. Fallback when a chapter has no pericope data: the whole chapter behaves as one pericope.
+4. **Save path (PoC shape of the R&D §4 dual-write):** `onUsjChange` → merge slice into chapter USJ → derive per-verse texts → live "derived verse rows" panel proves verse-mode compatibility. Actual `POST /translated-verses` is a deliberate opt-in button, not automatic.
+5. **Format bar:** no permanent toolbar (requirements constraint). A minimal floating bar toggled by keyboard (and auto-hidden), carrying only undo/redo and paragraph-break insertion; structural actions stay keyboard-first.
+6. **Lynx highlights:** reuse the existing `src/features/lynx` workspace (from PR #327). New mapper turns Lynx diagnostics (line/char over the assembled USFM) into `AnnotationRange` (USJ jsonPath + offset) — the spike-3 bridge promoted to app code — applied via `editorRef.setAnnotation`.
+
+## Architecture
+
+```
+src/features/rte/
+  lib/
+    usfm-to-usj.ts        # curated-subset USFM → USJ (deterministic)
+    usj-verses.ts         # USJ → per-verse texts (save-path derivation)
+    pericope-slice.ts     # slice chapter USJ by verse list + merge back
+    lynx-annotations.ts   # Lynx diagnostics → AnnotationRange[]
+  hooks/
+    useRtePoc.ts          # page state: chapter USJ, slice, dirty state, derived verses
+  components/
+    RtePocPage.tsx        # route shell: source controls, pericope selector, panels
+    RteEditor.tsx         # Editorial wrapper (ref, usj in/out, annotations, format bar)
+    FormatBar.tsx         # on-demand floating bar
+    DerivedVersesPanel.tsx
+src/routes/_authenticated/rte-poc.tsx
+```
+
+Data flow: verses (seed sample or bible-texts endpoint) → assemble USFM (existing lynx lib) → `usfmToUsj` → chapter USJ → `slicePericope` → Editorial → `onUsjChange` → `mergePericope` → `usjToVerses` → derived panel (+ optional POST). Lynx runs on the assembled USFM of the current chapter state; diagnostics map to annotations on the slice.
+
+## Testing
+
+TDD on the four lib modules (vitest, colocated): golden USFM→USJ conversion incl. multi-paragraph verses; verse extraction round-trip (verses → USFM → USJ → verses is identity); slice/merge identity and edit-merge; annotation mapping incl. out-of-slice diagnostics dropped. UI verified live in the browser (screenshots), matching the Lynx PoC precedent.
+
+## Comparison harness (for the ProseMirror increment)
+
+The page keeps editor-specific code behind `RteEditor` so the ProseMirror counterpart swaps that component only; both share lib/hooks/panels, making the step-3 comparison apples-to-apples. Measurements (chapter load, typing latency, annotation apply) run CPU-throttled via DevTools on both, appended to the R&D doc scorecard.
+
+## Out of scope
+
+Formatted view, section headings, footnote UI, verse-bridge UI, the `chapter_documents` storage PR, converter canonicalization, real-time collab.

--- a/docs/proposals/rte-poc/design.md
+++ b/docs/proposals/rte-poc/design.md
@@ -19,7 +19,7 @@ Roadmap step 3 for the Rich Text Editor: a working pericope-view editing PoC ins
 
 ## Architecture
 
-```
+```text
 src/features/rte/
   lib/
     usfm-to-usj.ts        # curated-subset USFM → USJ (deterministic)
@@ -45,6 +45,15 @@ TDD on the four lib modules (vitest, colocated): golden USFM→USJ conversion in
 ## Comparison harness (for the ProseMirror increment)
 
 The page keeps editor-specific code behind `RteEditor` so the ProseMirror counterpart swaps that component only; both share lib/hooks/panels, making the step-3 comparison apples-to-apples. Measurements (chapter load, typing latency, annotation apply) run CPU-throttled via DevTools on both, appended to the R&D doc scorecard.
+
+## Known limitations
+
+Behaviours a production version must close, recorded from the working PoC rather than inferred.
+
+- **The converter drops what it does not know.** `usfmToUsj` handles `\id \h \mt \c \p \v` plus plain continuation lines; any other marker is silently omitted, and malformed lines fall through as text. That is safe _only_ because its input is USFM this app assembled from verse rows moments earlier, never imported or user-authored USFM. Point it at real Paratext USFM and content disappears without a trace. Before it feeds anything that gets saved, it needs to fail closed on unknown markers (reject, or preserve them verbatim) and carry fixtures per supported marker plus one unsupported-marker case.
+- **The pericope fallback cannot distinguish "no pericopes" from "not loaded yet".** The whole-chapter fallback triggers whenever `useChapterPericopes` has no data — which is also true while the query is disabled (no project id), pending, or errored. A user whose pericope fetch fails silently gets a whole-chapter editor that looks deliberate. Production should branch on query state and treat only a settled empty result as "this chapter has none".
+- **The save contract is PoC-shaped.** The opt-in button posts changed verses one `POST /translated-verses` per row, sequentially, skipping rows whose `bibleTextId` is unknown and reporting saved/skipped counts. There is no batching, no retry, no optimistic state, and nothing prevents a second click from re-posting rows already in flight. A real dual-write needs the batch-vs-single decision made explicitly, plus duplicate-submit and partial-failure handling.
+- **The format bar is keyboard-first by requirement, which costs discoverability.** No permanent toolbar was allowed, so the bar is toggled by keyboard and auto-hides. As built that leaves pointer, touch and assistive-technology users without a route to it. Shipping this shape needs a focusable trigger with an accessible name, `aria-expanded`/`aria-controls`, the bar staying visible while it or its trigger holds focus, and Escape to dismiss.
 
 ## Out of scope
 


### PR DESCRIPTION
Splits the design docs out of #327 so they can land on `main` while the PoC code stays where it was asked to stay.

> This branch should stay a reference branch with only the design docs landing.
> — @kaseywright on #327

## What's here

Three docs, +238 lines, no code:

- **`docs/proposals/lynx-client-usfm-poc/design.md`** — the client-side USFM PoC design: goal and non-goals, approaches considered, architecture and edit-cycle data flow, the three browser-packaging hazards found and worked around (file-based `UsfmStylesheet` construction, module-scope Node calls in `@sillsdev/machine`, bundler-hostile locale loading), measured timings (~3 ms sample, ~28 ms for a real 31-verse chapter), bundle cost (75 KB gzip, lazy route chunk), and the verification plan.
- **`docs/proposals/lynx-client-usfm-poc/lynx-fluent-assessment.md`** — what Lynx buys Fluent, mapped concept-by-concept against the Repeated Word Check UI proposal (#305), ranked opportunities (checks-panel engine, Greek Room/Wildebeest as providers, per-language rule sets, export linting, editor/document-model decision, mobile), what Fluent can contribute upstream, risks, and suggested next steps.
- **`docs/proposals/rte-poc/design.md`** — the RTE PoC design for #375: SharedEditor in-app, pericope-scoped editing, the on-demand format bar, the USJ save path, Lynx check highlights, and the comparison harness that keeps the ProseMirror counterpart apples-to-apples.

## Differences from the versions on #327

Header lines only. Each doc now states that the code stays on its reference branch and links #327, because `/lynx-usfm` and `/rte-poc` don't exist on `main`. All other prose is unchanged.

#327 stays open as the reference branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a design proposal for a client-side USFM proof of concept, covering diagnostics, verse mapping, quick fixes, dismissals, smart quotes, compatibility, and performance.
  - Added an assessment of Lynx integration opportunities, architecture, risks, open questions, and recommended next steps.
  - Added a proposal for a shared rich-text editor proof of concept, including pericope-scoped editing, formatting controls, annotation support, save flows, conversion, testing, and known limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->